### PR TITLE
[Feature] Support reading and writing index files on remote file systems

### DIFF
--- a/tenann/builder/index_builder.cc
+++ b/tenann/builder/index_builder.cc
@@ -39,6 +39,12 @@ IndexBuilder& IndexBuilder::SetBuildOptions(const json& options) {
   return *this;
 }
 
+IndexBuilder& IndexBuilder::SetFileWriter(IndexFileWriterPtr writer) {
+  T_LOG_IF(ERROR, is_opened()) << "all confuration actions must be called before index being opened";
+  index_writer_->SetFileWriter(std::move(writer));
+  return *this;
+}
+
 IndexBuilder& IndexBuilder::EnableCustomRowId() {
   T_LOG_IF(ERROR, is_opened()) << "all confuration actions must be called before index being opened";
   use_custom_row_id_ = true;

--- a/tenann/builder/index_builder.h
+++ b/tenann/builder/index_builder.h
@@ -22,6 +22,7 @@
 #include "tenann/common/seq_view.h"
 #include "tenann/index/index_reader.h"
 #include "tenann/index/index_writer.h"
+#include "tenann/store/index_file_writer.h"
 #include "tenann/store/index_meta.h"
 #include "tenann/util/runtime_profile.h"
 
@@ -85,6 +86,7 @@ class IndexBuilder {
 
   /** Setters */
   IndexBuilder& SetBuildOptions(const json& options);
+  IndexBuilder& SetFileWriter(IndexFileWriterPtr writer);
   IndexBuilder& EnableCustomRowId();
   IndexBuilder& EnableProfile();
   IndexBuilder& DisableProfile();

--- a/tenann/index/custom_io_reader.h
+++ b/tenann/index/custom_io_reader.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "faiss/impl/io.h"
+#include "tenann/store/index_file_reader.h"
+
+namespace tenann {
+
+/// A faiss::IOReader implementation that delegates all reads to an
+/// IndexFileReader, allowing FAISS to read from remote file systems.
+class CustomFaissIOReader : public faiss::IOReader {
+ public:
+  explicit CustomFaissIOReader(IndexFileReaderPtr reader) : reader_(std::move(reader)), bytes_read_(0) {
+    name = reader_->filename();
+  }
+
+  /// Called by FAISS IO macros (READ1, READVECTOR, etc.).
+  /// Semantics match fread(): returns number of complete items read.
+  size_t operator()(void* ptr, size_t size, size_t nitems) override {
+    int64_t total = static_cast<int64_t>(size) * static_cast<int64_t>(nitems);
+    int64_t n = reader_->Read(ptr, total);
+    if (n <= 0) return 0;
+    bytes_read_ += static_cast<size_t>(n);
+    return static_cast<size_t>(n) / size;
+  }
+
+  /// Returns the total number of bytes read through this IOReader so far.
+  /// Used to determine the file offset at which inverted lists data starts.
+  size_t bytes_read() const { return bytes_read_; }
+
+  IndexFileReaderPtr reader_;
+
+ private:
+  size_t bytes_read_;
+};
+
+}  // namespace tenann

--- a/tenann/index/faiss_index_reader.cc
+++ b/tenann/index/faiss_index_reader.cc
@@ -23,7 +23,7 @@
 #include "faiss/impl/FaissException.h"
 #include "faiss/index_io.h"
 #include "tenann/common/logging.h"
-#include "tenann/index/custom_io_reader.h"
+#include "tenann/index/faiss_io_reader_adapter.h"
 
 namespace tenann {
 
@@ -36,7 +36,7 @@ IndexRef FaissIndexReader::ReadIndexFile(const std::string& path) {
     if (file_reader_) {
       // Use external file reader (for remote file systems).
       // Cannot use MMAP with remote FS, use IO_FLAG_READ_ONLY instead.
-      CustomFaissIOReader io_reader(file_reader_);
+      FaissIOReaderAdapter io_reader(file_reader_);
       raw_index = faiss::read_index(&io_reader, faiss::IO_FLAG_READ_ONLY);
     } else {
       // Local file path: use MMAP for best performance.

--- a/tenann/index/faiss_index_reader.cc
+++ b/tenann/index/faiss_index_reader.cc
@@ -23,6 +23,7 @@
 #include "faiss/impl/FaissException.h"
 #include "faiss/index_io.h"
 #include "tenann/common/logging.h"
+#include "tenann/index/custom_io_reader.h"
 
 namespace tenann {
 
@@ -30,14 +31,25 @@ FaissIndexReader::~FaissIndexReader() = default;
 
 IndexRef FaissIndexReader::ReadIndexFile(const std::string& path) {
   try {
-    auto faiss_index =
-        std::unique_ptr<faiss::Index>(faiss::read_index(path.c_str(), faiss::IO_FLAG_MMAP));
-    return std::make_shared<Index>(faiss_index.release(),  //
+    faiss::Index* raw_index = nullptr;
+
+    if (file_reader_) {
+      // Use external file reader (for remote file systems).
+      // Cannot use MMAP with remote FS, use IO_FLAG_READ_ONLY instead.
+      CustomFaissIOReader io_reader(file_reader_);
+      raw_index = faiss::read_index(&io_reader, faiss::IO_FLAG_READ_ONLY);
+    } else {
+      // Local file path: use MMAP for best performance.
+      raw_index = faiss::read_index(path.c_str(), faiss::IO_FLAG_MMAP);
+    }
+
+    return std::make_shared<Index>(raw_index,  //
                                    (IndexType)index_meta_.index_type(),
                                    [](void* index) { delete static_cast<faiss::Index*>(index); });
   } catch (faiss::FaissException& e) {
     T_LOG(ERROR) << e.what();
   }
+  return nullptr;
 }
 
 }  // namespace tenann

--- a/tenann/index/faiss_index_writer.cc
+++ b/tenann/index/faiss_index_writer.cc
@@ -23,6 +23,7 @@
 #include "faiss/impl/FaissException.h"
 #include "faiss/index_io.h"
 #include "tenann/common/logging.h"
+#include "tenann/index/faiss_io_writer_adapter.h"
 
 namespace tenann {
 
@@ -31,7 +32,12 @@ FaissIndexWriter::~FaissIndexWriter() = default;
 void FaissIndexWriter::WriteIndexFile(IndexRef index, const std::string& path) {
   try {
     auto faiss_index = static_cast<faiss::Index*>(index->index_raw());
-    faiss::write_index(faiss_index, path.c_str());
+    if (file_writer_) {
+      FaissIOWriterAdapter adapter(file_writer_);
+      faiss::write_index(faiss_index, &adapter);
+    } else {
+      faiss::write_index(faiss_index, path.c_str());
+    }
   } catch (faiss::FaissException& e) {
     T_LOG(ERROR) << e.what();
   }

--- a/tenann/index/faiss_io_reader_adapter.h
+++ b/tenann/index/faiss_io_reader_adapter.h
@@ -29,9 +29,9 @@ namespace tenann {
 
 /// A faiss::IOReader implementation that delegates all reads to an
 /// IndexFileReader, allowing FAISS to read from remote file systems.
-class CustomFaissIOReader : public faiss::IOReader {
+class FaissIOReaderAdapter : public faiss::IOReader {
  public:
-  explicit CustomFaissIOReader(IndexFileReaderPtr reader) : reader_(std::move(reader)), bytes_read_(0) {
+  explicit FaissIOReaderAdapter(IndexFileReaderPtr reader) : reader_(std::move(reader)), bytes_read_(0) {
     name = reader_->filename();
   }
 

--- a/tenann/index/faiss_io_writer_adapter.h
+++ b/tenann/index/faiss_io_writer_adapter.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "faiss/impl/io.h"
+#include "tenann/store/index_file_writer.h"
+
+namespace tenann {
+
+/// A faiss::IOWriter implementation that delegates all writes to an
+/// IndexFileWriter, allowing FAISS to write to remote file systems.
+class FaissIOWriterAdapter : public faiss::IOWriter {
+ public:
+  explicit FaissIOWriterAdapter(IndexFileWriterPtr writer) : writer_(std::move(writer)) {
+    name = writer_->filename();
+  }
+
+  /// Called by FAISS IO macros (WRITE1, WRITEVECTOR, etc.).
+  /// Semantics match fwrite(): returns number of complete items written.
+  size_t operator()(const void* ptr, size_t size, size_t nitems) override {
+    int64_t total = static_cast<int64_t>(size) * static_cast<int64_t>(nitems);
+    int64_t n = writer_->Write(ptr, total);
+    if (n <= 0) return 0;
+    return static_cast<size_t>(n) / size;
+  }
+
+ private:
+  IndexFileWriterPtr writer_;
+};
+
+}  // namespace tenann

--- a/tenann/index/index_ivfpq_reader.cc
+++ b/tenann/index/index_ivfpq_reader.cc
@@ -39,6 +39,7 @@
 #include "faiss/invlists/InvertedListsIOHook.h"
 #include "faiss/utils/hamming.h"
 #include "tenann/common/logging.h"
+#include "tenann/index/custom_io_reader.h"
 #include "tenann/index/internal/index_ivfpq.h"
 #include "tenann/util/defer.h"
 
@@ -130,7 +131,8 @@ static void read_ArrayInvertedLists_sizes(IOReader* f, std::vector<size_t>& size
 }
 
 InvertedLists* read_InvertedLists_with_block_cache(IOReader* f, int io_flags,
-                                                   tenann::IndexCache* index_cache) {
+                                                   tenann::IndexCache* index_cache,
+                                                   tenann::IndexFileReaderPtr file_reader = nullptr) {
   uint32_t h;
   READ1(h);
   if (h == fourcc("il00")) {
@@ -145,17 +147,22 @@ InvertedLists* read_InvertedLists_with_block_cache(IOReader* f, int io_flags,
     std::vector<size_t> sizes(nlist);
     read_ArrayInvertedLists_sizes(f, sizes);
     auto bc = std::make_shared<BlockCacheInvertedListsIOHook>(index_cache);
-    return bc->read_ArrayInvertedLists(f, io_flags, nlist, code_size, sizes);
+    if (file_reader) {
+      return bc->read_ArrayInvertedLists(f, io_flags, nlist, code_size, sizes, std::move(file_reader));
+    } else {
+      return bc->read_ArrayInvertedLists(f, io_flags, nlist, code_size, sizes);
+    }
   } else {
     return InvertedListsIOHook::lookup(h)->read(f, io_flags);
   }
 }
 
 static void read_InvertedLists(IndexIVF* ivf, IOReader* f, int io_flags, bool cache_index_block,
-                               tenann::IndexCache* index_cache) {
+                               tenann::IndexCache* index_cache,
+                               tenann::IndexFileReaderPtr file_reader = nullptr) {
   InvertedLists* ils = nullptr;
   if (cache_index_block) {
-    ils = read_InvertedLists_with_block_cache(f, io_flags, index_cache);
+    ils = read_InvertedLists_with_block_cache(f, io_flags, index_cache, std::move(file_reader));
   } else {
     ils = read_InvertedLists(f, io_flags);
   }
@@ -181,7 +188,8 @@ static void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f) {
  **************************************************************/
 
 static void read_ivfpq(IndexIVFPQ* ivpq, IOReader* f, uint32_t h, int io_flags,
-                       bool cache_index_block, tenann::IndexCache* index_cache) {
+                       bool cache_index_block, tenann::IndexCache* index_cache,
+                       tenann::IndexFileReaderPtr file_reader = nullptr) {
   bool legacy = h == fourcc("IvQR") || h == fourcc("IvPQ");
 
   std::vector<std::vector<idx_t>> ids;
@@ -194,7 +202,7 @@ static void read_ivfpq(IndexIVFPQ* ivpq, IOReader* f, uint32_t h, int io_flags,
     ArrayInvertedLists* ail = set_array_invlist(ivpq, ids);
     for (size_t i = 0; i < ail->nlist; i++) READVECTOR(ail->codes[i]);
   } else {
-    read_InvertedLists(ivpq, f, io_flags, cache_index_block, index_cache);
+    read_InvertedLists(ivpq, f, io_flags, cache_index_block, index_cache, std::move(file_reader));
   }
 
   if (ivpq->is_trained) {
@@ -230,7 +238,7 @@ BlockCacheInvertedLists::BlockCacheInvertedLists(tenann::IndexCache* index_cache
     : BlockCacheInvertedLists(0, 0, "", index_cache) {}
 
 BlockCacheInvertedLists::~BlockCacheInvertedLists() {
-  // close file
+  // close file (only if using local fd)
   if (fd != -1) {
     close(fd);
   }
@@ -259,37 +267,51 @@ const uint8_t* BlockCacheInvertedLists::get_ptr(size_t list_no) const {
   size_t offset = lists[list_no].offset;
   size_t size = lists[list_no].size * one_entry_size;
 
-  // Align the offset to the block size
-  size_t aligned_offset = (offset / block_size) * block_size;
+  ssize_t read_bytes = 0;
+  void* buffer = nullptr;
 
-  // Adjust the size to read to include the data from the aligned offset
-  size_t aligned_size =
-      ((offset_difference[list_no] + size + block_size - 1) / block_size) * block_size;
+  if (file_reader) {
+    // ---- Remote file system path: use IndexFileReader::ReadAt ----
+    // No O_DIRECT / alignment needed for remote FS.
+    buffer = malloc(size);
+    FAISS_THROW_IF_NOT_FMT(buffer != nullptr, "malloc(%zu) failed", size);
 
-  // Allocate aligned memory
-  void* buffer;
-  int err = posix_memalign(&buffer, block_size, aligned_size);
-  FAISS_THROW_IF_NOT_FMT(err == 0, "posix_memalign error: %d", err);
+    read_bytes = file_reader->ReadAt(offset, buffer, size);
+    FAISS_THROW_IF_NOT_FMT(read_bytes == static_cast<ssize_t>(size),
+                           "ReadAt: read_bytes: %zd, expected: %zu", read_bytes, size);
 
-  // Seek to the aligned offset
-  off_t seek_result = lseek(fd, aligned_offset, SEEK_SET);
-  FAISS_THROW_IF_NOT_FMT(seek_result != -1, "lseek to aligned_offset %zu failed: %s",
-                         aligned_offset, strerror(errno));
+    // No alignment offset for remote reads
+    offset_difference[list_no] = 0;
+  } else {
+    // ---- Local file system path: original POSIX O_DIRECT logic ----
 
-  size_t remaining_size = totsize - aligned_offset;
-  size_t expected_read_size = std::min(remaining_size, aligned_size);
-  // Perform the read operation
-  ssize_t read_bytes = read(fd, buffer, aligned_size);
-  FAISS_THROW_IF_NOT_FMT(read_bytes == expected_read_size,
-                         "read_bytes: %zd, expected_read_size: %zu", read_bytes,
-                         expected_read_size);
+    // Align the offset to the block size
+    size_t aligned_offset = (offset / block_size) * block_size;
 
-  // auto msg = fmt::format("allocated {};\n", buffer);
-  // std::cerr << msg;
+    // Adjust the size to read to include the data from the aligned offset
+    size_t aligned_size =
+        ((offset_difference[list_no] + size + block_size - 1) / block_size) * block_size;
+
+    // Allocate aligned memory
+    int err = posix_memalign(&buffer, block_size, aligned_size);
+    FAISS_THROW_IF_NOT_FMT(err == 0, "posix_memalign error: %d", err);
+
+    // Seek to the aligned offset
+    off_t seek_result = lseek(fd, aligned_offset, SEEK_SET);
+    FAISS_THROW_IF_NOT_FMT(seek_result != -1, "lseek to aligned_offset %zu failed: %s",
+                           aligned_offset, strerror(errno));
+
+    size_t remaining_size = totsize - aligned_offset;
+    size_t expected_read_size = std::min(remaining_size, aligned_size);
+    // Perform the read operation
+    read_bytes = read(fd, buffer, aligned_size);
+    FAISS_THROW_IF_NOT_FMT(read_bytes == expected_read_size,
+                           "read_bytes: %zd, expected_read_size: %zu", read_bytes,
+                           expected_read_size);
+  }
+
   auto index_ref = std::make_shared<tenann::Index>(
       buffer, tenann::IndexType::kFaissIvfPqOneInvertedList, [](void* index) {
-        // auto msg = fmt::format("freeing {};\n", index);
-        // std::cerr << msg;
         free(index);
       });
 
@@ -328,18 +350,13 @@ BlockCacheInvertedListsIOHook::BlockCacheInvertedListsIOHook(tenann::IndexCache*
     : InvertedListsIOHook("ilbc", typeid(BlockCacheInvertedLists).name()),
       index_cache(index_cache) {}
 
+// Original local-file version
 InvertedLists* BlockCacheInvertedListsIOHook::read_ArrayInvertedLists(
     IOReader* f, int /* io_flags */, size_t nlist, size_t code_size,
     const std::vector<size_t>& sizes) const {
   auto ails =
       std::make_unique<BlockCacheInvertedLists>(nlist, code_size, f->name.c_str(), index_cache);
-  // ails->filename = f->name;
-  // ails->nlist = nlist;
-  // ails->code_size = code_size;
   ails->read_only = true;
-  // ails->lists.resize(nlist);
-  // ails->cache_keys.resize(nlist);
-  // ails->offset_difference.resize(nlist);
 
   FileIOReader* reader = dynamic_cast<FileIOReader*>(f);
   FAISS_THROW_IF_NOT_MSG(reader, "only supported for File objects");
@@ -381,6 +398,51 @@ InvertedLists* BlockCacheInvertedListsIOHook::read_ArrayInvertedLists(
   return ails.release();
 }
 
+// Remote file system version: uses IndexFileReader instead of POSIX fd
+InvertedLists* BlockCacheInvertedListsIOHook::read_ArrayInvertedLists(
+    IOReader* f, int /* io_flags */, size_t nlist, size_t code_size,
+    const std::vector<size_t>& sizes,
+    tenann::IndexFileReaderPtr file_reader) const {
+  auto ails =
+      std::make_unique<BlockCacheInvertedLists>(nlist, code_size, f->name.c_str(), index_cache);
+  ails->read_only = true;
+  ails->file_reader = file_reader;
+  // fd stays -1; all reads go through file_reader
+
+  ails->totsize = file_reader->GetSize();
+
+  // Use CustomFaissIOReader::bytes_read() to determine the start offset of
+  // inverted list data. The IOReader has consumed the file header sequentially,
+  // so bytes_read() tells us exactly where inverted lists data starts.
+  tenann::CustomFaissIOReader* custom_reader = dynamic_cast<tenann::CustomFaissIOReader*>(f);
+  ails->start_offset = custom_reader ? custom_reader->bytes_read() : 0;
+  size_t o = ails->start_offset;
+
+  // For remote FS, use hash(filename) + file_size as cache key (no mtime available).
+  std::string prefix = std::to_string(std::hash<std::string>{}(ails->filename)) + "_" +
+                       std::to_string(ails->totsize) + "_";
+  for (size_t i = 0; i < nlist; i++) {
+    ails->cache_keys[i] = prefix + std::to_string(i);
+  }
+
+  ails->one_entry_size = sizeof(idx_t) + ails->code_size;
+  for (size_t i = 0; i < ails->nlist; i++) {
+    BlockCacheInvertedLists::List& l = ails->lists[i];
+    l.size = l.capacity = sizes[i];
+    l.offset = o;
+    o += l.size * ails->one_entry_size;
+
+    // No block alignment needed for remote FS reads
+    ails->offset_difference[i] = 0;
+  }
+
+  // Advance file_reader past inverted lists data so the caller can
+  // continue reading trailing fields (range_search_confidence, etc.).
+  file_reader->Seek(o);
+
+  return ails.release();
+}
+
 }  // namespace faiss
 
 namespace tenann {
@@ -393,8 +455,12 @@ static constexpr const int IO_FLAG = faiss::IO_FLAG_READ_ONLY;
 IndexIvfPqReader::~IndexIvfPqReader() = default;
 
 IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
-  // open the index file and close it automatically
-  // when we leave the current scope through `Defer`
+  if (file_reader_) {
+    // ---- Remote file system path: use CustomFaissIOReader ----
+    return ReadIndexFileFromReader(path);
+  }
+
+  // ---- Local file system path: original fopen logic ----
   auto file = fopen(path.c_str(), "rb");
   Defer defer([file]() {
     if (file != nullptr) fclose(file);
@@ -477,6 +543,70 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
     return nullptr;
   }
   return nullptr;  // Should not reach here
+}
+
+IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
+  try {
+    CustomFaissIOReader reader(file_reader_);
+    auto* f = &reader;
+
+    uint32_t h;
+    READ1(h);
+    T_LOG_IF(WARNING, h != fourcc("IwPQ") && h != fourcc("IxPT"))
+        << "tenann could not read ivfpq from file " << path << ": "
+        << "expect magic number `IwPQ` and `IxPT` but got." << fourcc_inv_printable(h);
+    if (h == fourcc("IwPQ")) {
+      auto index_ivfpq = std::make_unique<IndexIvfPq>();
+      VLOG(VERBOSE_DEBUG) << "cache_index_block: " << index_reader_options_.cache_index_block;
+      faiss::read_ivfpq(index_ivfpq.get(), f, h, IO_FLAG, index_reader_options_.cache_index_block,
+                        index_cache(), file_reader_);
+      READ1(index_ivfpq->range_search_confidence);
+      size_t num_invlists;
+      READ1(num_invlists);
+      index_ivfpq->reconstruction_errors.resize(num_invlists);
+      for (size_t i = 0; i < num_invlists; i++) {
+        READVECTOR(index_ivfpq->reconstruction_errors[i]);
+      }
+      return std::make_shared<Index>(index_ivfpq.release(),   //
+                                     IndexType::kFaissIvfPq,  //
+                                     [](void* index) { delete static_cast<faiss::Index*>(index); });
+    } else if (h == fourcc("IxPT")) {
+      auto index_pt = std::make_unique<faiss::IndexPreTransform>();
+      index_pt->own_fields = true;
+      faiss::read_index_header(index_pt.get(), f);
+      int nt;
+      READ1(nt);
+      for (int i = 0; i < nt; i++) {
+        index_pt->chain.push_back(read_VectorTransform(f));
+      }
+      auto index_ivfpq = std::make_unique<IndexIvfPq>();
+      READ1(h);
+      VLOG(VERBOSE_DEBUG) << "cache_index_block: " << index_reader_options_.cache_index_block;
+      faiss::read_ivfpq(index_ivfpq.get(), f, h, IO_FLAG, index_reader_options_.cache_index_block,
+                        index_cache(), file_reader_);
+      READ1(index_ivfpq->range_search_confidence);
+      size_t num_invlists;
+      READ1(num_invlists);
+      index_ivfpq->reconstruction_errors.resize(num_invlists);
+      for (size_t i = 0; i < num_invlists; i++) {
+        READVECTOR(index_ivfpq->reconstruction_errors[i]);
+      }
+      index_pt->index = index_ivfpq.release();
+      return std::make_shared<Index>(
+          index_pt.release(),      //
+          IndexType::kFaissIvfPq,  //
+          [](void* index) { delete static_cast<faiss::IndexPreTransform*>(index); });
+    } else {
+      T_LOG(INFO) << "Unknow index to tenann::reader. using faiss::reader";
+      return std::make_shared<Index>(faiss::read_index(f, IO_FLAG),  //
+                                     IndexType::kFaissIvfPq,         //
+                                     [](void* index) { delete static_cast<faiss::Index*>(index); });
+    }
+  } catch (faiss::FaissException& e) {
+    T_LOG(ERROR) << e.what();
+    return nullptr;
+  }
+  return nullptr;
 }
 
 }  // namespace tenann

--- a/tenann/index/index_ivfpq_reader.cc
+++ b/tenann/index/index_ivfpq_reader.cc
@@ -39,7 +39,7 @@
 #include "faiss/invlists/InvertedListsIOHook.h"
 #include "faiss/utils/hamming.h"
 #include "tenann/common/logging.h"
-#include "tenann/index/custom_io_reader.h"
+#include "tenann/index/faiss_io_reader_adapter.h"
 #include "tenann/index/internal/index_ivfpq.h"
 #include "tenann/util/defer.h"
 
@@ -411,11 +411,11 @@ InvertedLists* BlockCacheInvertedListsIOHook::read_ArrayInvertedLists(
 
   ails->totsize = file_reader->GetSize();
 
-  // Use CustomFaissIOReader::bytes_read() to determine the start offset of
+  // Use FaissIOReaderAdapter::bytes_read() to determine the start offset of
   // inverted list data. The IOReader has consumed the file header sequentially,
   // so bytes_read() tells us exactly where inverted lists data starts.
-  tenann::CustomFaissIOReader* custom_reader = dynamic_cast<tenann::CustomFaissIOReader*>(f);
-  ails->start_offset = custom_reader ? custom_reader->bytes_read() : 0;
+  tenann::FaissIOReaderAdapter* faiss_reader = dynamic_cast<tenann::FaissIOReaderAdapter*>(f);
+  ails->start_offset = faiss_reader ? faiss_reader->bytes_read() : 0;
   size_t o = ails->start_offset;
 
   // For remote FS, use hash(filename) + file_size as cache key (no mtime available).
@@ -456,7 +456,7 @@ IndexIvfPqReader::~IndexIvfPqReader() = default;
 
 IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
   if (file_reader_) {
-    // ---- Remote file system path: use CustomFaissIOReader ----
+    // ---- Remote file system path: use FaissIOReaderAdapter ----
     return ReadIndexFileFromReader(path);
   }
 
@@ -547,7 +547,7 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
 
 IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
   try {
-    CustomFaissIOReader reader(file_reader_);
+    FaissIOReaderAdapter reader(file_reader_);
     auto* f = &reader;
 
     uint32_t h;

--- a/tenann/index/index_ivfpq_reader.h
+++ b/tenann/index/index_ivfpq_reader.h
@@ -30,6 +30,7 @@
 #include "tenann/common/json.h"
 #include "tenann/index/index_cache.h"
 #include "tenann/index/index_reader.h"
+#include "tenann/store/index_file_reader.h"
 
 namespace faiss {
 
@@ -41,7 +42,7 @@ struct BlockCacheInvertedLists : InvertedLists {
   // size nlist
   std::vector<List> lists;
   std::vector<std::string> cache_keys;
-  std::vector<size_t> offset_difference;
+  mutable std::vector<size_t> offset_difference;
   /// Keep references to cache handles, otherwise the allocated memory may be clean
   mutable std::vector<tenann::IndexCacheHandle> cache_handles;
   /// Note that this class may be accessed by multiple threads,
@@ -56,6 +57,9 @@ struct BlockCacheInvertedLists : InvertedLists {
   bool read_only;            /// are inverted lists mapped read-only
   int fd = -1;
   tenann::IndexCache* index_cache = nullptr;
+  /// Optional external file reader for remote file systems.
+  /// When set, reads go through this reader instead of POSIX fd.
+  tenann::IndexFileReaderPtr file_reader;
 
   BlockCacheInvertedLists(size_t nlist, size_t code_size, const char* filename,
                           tenann::IndexCache* index_cache);
@@ -91,6 +95,10 @@ struct BlockCacheInvertedListsIOHook : InvertedListsIOHook {
   InvertedLists* read(IOReader* f, int io_flags) const { return nullptr; }
   InvertedLists* read_ArrayInvertedLists(IOReader* f, int io_flags, size_t nlist, size_t code_size,
                                          const std::vector<size_t>& sizes) const override;
+  /// Overload that accepts an external file reader for remote file systems.
+  InvertedLists* read_ArrayInvertedLists(IOReader* f, int io_flags, size_t nlist, size_t code_size,
+                                         const std::vector<size_t>& sizes,
+                                         tenann::IndexFileReaderPtr file_reader) const;
 
   tenann::IndexCache* index_cache = nullptr;
 };
@@ -108,6 +116,10 @@ class IndexIvfPqReader : public IndexReader {
   T_FORBID_MOVE(IndexIvfPqReader);
 
   IndexRef ReadIndexFile(const std::string& path) override;
+
+ private:
+  /// Read index file via external IndexFileReader (for remote file systems).
+  IndexRef ReadIndexFileFromReader(const std::string& path);
 };
 
 }  // namespace tenann

--- a/tenann/index/index_ivfpq_writer.cc
+++ b/tenann/index/index_ivfpq_writer.cc
@@ -26,6 +26,7 @@
 #include "faiss/impl/io_macros.h"
 #include "faiss/index_io.h"
 #include "tenann/common/logging.h"
+#include "tenann/index/faiss_io_writer_adapter.h"
 #include "tenann/index/internal/index_ivfpq.h"
 #include "tenann/util/defer.h"
 
@@ -47,59 +48,71 @@ void write_index_header(const faiss::Index* idx, faiss::IOWriter* f) {
 }
 
 void IndexIvfPqWriter::WriteIndexFile(IndexRef index, const std::string& path) {
-  // open the index file and close it automatically
-  // when we leave the current scope through `Defer`
-  auto file = fopen(path.c_str(), "wb");
-  Defer defer([file]() {
-    if (file != nullptr) fclose(file);
-  });
-
-  T_LOG_IF(ERROR, file == nullptr)
-      << "could not open[" << path << "] for writing: " << strerror(errno);
-
   try {
-    // write custom fields with faiss FileIOWriter and IO macros
-    faiss::FileIOWriter writer(file);
-    writer.name = path;
-    // the name `f` is needed for faiss IO macros
-    auto* f = &writer;
     const auto* faiss_index = static_cast<const faiss::Index*>(index->index_raw());
 
-    if (const IndexIvfPq* index_ivfpq = dynamic_cast<const IndexIvfPq*>(faiss_index)) {
-      faiss::write_index(index_ivfpq, f);
-      // write range_search_confidence
-      WRITE1(index_ivfpq->range_search_confidence);
-      // write reconstruction errors
-      size_t vec_size = index_ivfpq->reconstruction_errors.size();
-      WRITE1(vec_size);
-      for (const auto& sub_vec : index_ivfpq->reconstruction_errors) {
-        WRITEVECTOR(sub_vec);
-      }
-    } else if (const faiss::IndexPreTransform* ixpt =
-                   dynamic_cast<const faiss::IndexPreTransform*>(faiss_index)) {
-      uint32_t h = faiss::fourcc("IxPT");
-      WRITE1(h);
-      write_index_header(ixpt, f);
-      int nt = ixpt->chain.size();
-      WRITE1(nt);
-      for (int i = 0; i < nt; i++) {
-        write_VectorTransform(ixpt->chain[i], f);
-      }
-      const IndexIvfPq* index_ivfpq = dynamic_cast<const IndexIvfPq*>(ixpt->index);
-      faiss::write_index(index_ivfpq, f);
-      WRITE1(index_ivfpq->range_search_confidence);
-      // write reconstruction errors
-      size_t vec_size = index_ivfpq->reconstruction_errors.size();
-      WRITE1(vec_size);
-      for (const auto& sub_vec : index_ivfpq->reconstruction_errors) {
-        WRITEVECTOR(sub_vec);
-      }
+    if (file_writer_) {
+      // ---- Remote file system path: use FaissIOWriterAdapter ----
+      FaissIOWriterAdapter adapter(file_writer_);
+      auto* f = &adapter;
+
+      WriteIndexContent(faiss_index, f);
+
+      file_writer_->Flush();
     } else {
-      faiss::write_index(faiss_index, f);
-      T_LOG(INFO) << "Unknow index to writer. using faiss::write_index()";
+      // ---- Local file system path: original fopen logic ----
+      auto file = fopen(path.c_str(), "wb");
+      Defer defer([file]() {
+        if (file != nullptr) fclose(file);
+      });
+
+      T_LOG_IF(ERROR, file == nullptr)
+          << "could not open[" << path << "] for writing: " << strerror(errno);
+
+      faiss::FileIOWriter writer(file);
+      writer.name = path;
+      auto* f = &writer;
+
+      WriteIndexContent(faiss_index, f);
     }
   } catch (faiss::FaissException& e) {
     T_LOG(ERROR) << e.what();
+  }
+}
+
+void IndexIvfPqWriter::WriteIndexContent(const faiss::Index* faiss_index, faiss::IOWriter* f) {
+  if (const IndexIvfPq* index_ivfpq = dynamic_cast<const IndexIvfPq*>(faiss_index)) {
+    faiss::write_index(index_ivfpq, f);
+    // write range_search_confidence
+    WRITE1(index_ivfpq->range_search_confidence);
+    // write reconstruction errors
+    size_t vec_size = index_ivfpq->reconstruction_errors.size();
+    WRITE1(vec_size);
+    for (const auto& sub_vec : index_ivfpq->reconstruction_errors) {
+      WRITEVECTOR(sub_vec);
+    }
+  } else if (const faiss::IndexPreTransform* ixpt =
+                 dynamic_cast<const faiss::IndexPreTransform*>(faiss_index)) {
+    uint32_t h = faiss::fourcc("IxPT");
+    WRITE1(h);
+    write_index_header(ixpt, f);
+    int nt = ixpt->chain.size();
+    WRITE1(nt);
+    for (int i = 0; i < nt; i++) {
+      write_VectorTransform(ixpt->chain[i], f);
+    }
+    const IndexIvfPq* index_ivfpq = dynamic_cast<const IndexIvfPq*>(ixpt->index);
+    faiss::write_index(index_ivfpq, f);
+    WRITE1(index_ivfpq->range_search_confidence);
+    // write reconstruction errors
+    size_t vec_size = index_ivfpq->reconstruction_errors.size();
+    WRITE1(vec_size);
+    for (const auto& sub_vec : index_ivfpq->reconstruction_errors) {
+      WRITEVECTOR(sub_vec);
+    }
+  } else {
+    faiss::write_index(faiss_index, f);
+    T_LOG(INFO) << "Unknow index to writer. using faiss::write_index()";
   }
 }
 

--- a/tenann/index/index_ivfpq_writer.h
+++ b/tenann/index/index_ivfpq_writer.h
@@ -19,6 +19,9 @@
 
 #pragma once
 
+#include "faiss/Index.h"
+#include "faiss/impl/io.h"
+
 #include "tenann/common/json.h"
 #include "tenann/index/index_writer.h"
 
@@ -34,6 +37,10 @@ class IndexIvfPqWriter: public IndexWriter {
 
   // Write index file
   void WriteIndexFile(IndexRef index, const std::string& path) override;
+
+ private:
+  // Shared logic for writing index content via an IOWriter
+  void WriteIndexContent(const faiss::Index* faiss_index, faiss::IOWriter* f);
 };
 
 }  // namespace tenann

--- a/tenann/index/index_reader.cc
+++ b/tenann/index/index_reader.cc
@@ -63,8 +63,15 @@ IndexReader& IndexReader::SetIndexCache(IndexCache* cache) {
   return *this;
 }
 
+IndexReader& IndexReader::SetFileReader(IndexFileReaderPtr reader) {
+  file_reader_ = std::move(reader);
+  return *this;
+}
+
 IndexCache* IndexReader::index_cache() { return index_cache_; }
 
 const IndexCache* IndexReader::index_cache() const { return index_cache_; }
+
+IndexFileReaderPtr IndexReader::file_reader() const { return file_reader_; }
 
 }  // namespace tenann

--- a/tenann/index/index_reader.h
+++ b/tenann/index/index_reader.h
@@ -25,6 +25,7 @@
 #include "tenann/index/index.h"
 #include "tenann/index/parameters.h"
 #include "tenann/index/index_cache.h"
+#include "tenann/store/index_file_reader.h"
 
 namespace tenann {
 
@@ -45,11 +46,13 @@ class IndexReader {
 
   /** Setters */
   IndexReader& SetIndexCache(IndexCache* cache);
+  IndexReader& SetFileReader(IndexFileReaderPtr reader);
 
   /** Getters */
   const IndexMeta& index_meta() const;
   IndexCache* index_cache();
   const IndexCache* index_cache() const;
+  IndexFileReaderPtr file_reader() const;
 
  protected:
   /// @brief index meta
@@ -64,6 +67,8 @@ class IndexReader {
    *
    */
   IndexCacheHandle cache_handle_;
+  /// @brief optional external file reader for remote file systems
+  IndexFileReaderPtr file_reader_;
 
   IndexRef ForceReadIndexAndOverwriteCache(const std::string& path, const std::string& cache_key);
 };

--- a/tenann/index/index_writer.cc
+++ b/tenann/index/index_writer.cc
@@ -53,6 +53,11 @@ IndexWriter& IndexWriter::SetIndexCache(IndexCache* cache) {
   return *this;
 }
 
+IndexWriter& IndexWriter::SetFileWriter(IndexFileWriterPtr writer) {
+  file_writer_ = std::move(writer);
+  return *this;
+}
+
 IndexCache* IndexWriter::index_cache() { return index_cache_; }
 
 const IndexCache* IndexWriter::index_cache() const { return index_cache_; }

--- a/tenann/index/index_writer.h
+++ b/tenann/index/index_writer.h
@@ -25,6 +25,7 @@
 #include "tenann/index/index.h"
 #include "tenann/index/index_cache.h"
 #include "tenann/index/parameters.h"
+#include "tenann/store/index_file_writer.h"
 
 namespace tenann {
 
@@ -45,6 +46,7 @@ class IndexWriter {
 
   /** Setters */
   IndexWriter& SetIndexCache(IndexCache* cache);
+  IndexWriter& SetFileWriter(IndexFileWriterPtr writer);
 
   /** Getters */
   const IndexMeta& index_meta() const;
@@ -60,6 +62,8 @@ class IndexWriter {
   IndexWriterOptions index_writer_options_;
   /* cache */
   IndexCache* index_cache_ = nullptr;
+  /* optional external file writer for remote file systems */
+  IndexFileWriterPtr file_writer_;
 };
 
 using IndexWriterRef = std::shared_ptr<IndexWriter>;

--- a/tenann/searcher/searcher.h
+++ b/tenann/searcher/searcher.h
@@ -23,6 +23,7 @@
 
 #include "tenann/common/macros.h"
 #include "tenann/index/index_reader.h"
+#include "tenann/store/index_file_reader.h"
 #include "tenann/store/index_meta.h"
 #include "tenann/factory/index_factory.h"
 
@@ -48,6 +49,16 @@ class Searcher {
 
   ChildSearcher& ReadIndex(const std::string& path) {
     index_ref_ = index_reader_->ReadIndex(path);
+    is_index_loaded_ = true;
+
+    OnIndexLoaded();
+    return static_cast<ChildSearcher&>(*this);
+  };
+
+  /// Read index via an external file reader (for remote file systems).
+  ChildSearcher& ReadIndex(IndexFileReaderPtr file_reader) {
+    index_reader_->SetFileReader(file_reader);
+    index_ref_ = index_reader_->ReadIndex(file_reader->filename());
     is_index_loaded_ = true;
 
     OnIndexLoaded();

--- a/tenann/store/index_file_reader.h
+++ b/tenann/store/index_file_reader.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace tenann {
+
+/// Abstract file reader interface that allows TenANN to read index files
+/// from arbitrary file systems (local, S3, HDFS, etc.).
+///
+/// Callers implement this interface to bridge their own file system
+/// abstraction into TenANN's index reading path.
+class IndexFileReader {
+ public:
+  virtual ~IndexFileReader() = default;
+
+  /// Sequential read: read up to |count| bytes from current position.
+  /// Returns the number of bytes actually read, or -1 on error.
+  virtual int64_t Read(void* data, int64_t count) = 0;
+
+  /// Random read: read up to |count| bytes starting at |offset|.
+  /// The current position is not affected.
+  /// Returns the number of bytes actually read, or -1 on error.
+  virtual int64_t ReadAt(int64_t offset, void* data, int64_t count) = 0;
+
+  /// Seek to the given absolute |position|.
+  virtual void Seek(int64_t position) = 0;
+
+  /// Returns the total file size in bytes.
+  virtual int64_t GetSize() = 0;
+
+  /// Returns the file name / path (used for cache key generation).
+  virtual const std::string& filename() const = 0;
+};
+
+using IndexFileReaderPtr = std::shared_ptr<IndexFileReader>;
+
+}  // namespace tenann

--- a/tenann/store/index_file_writer.h
+++ b/tenann/store/index_file_writer.h
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace tenann {
+
+/// Abstract file writer interface that allows TenANN to write index files
+/// to arbitrary file systems (local, S3, HDFS, etc.).
+///
+/// Callers implement this interface to bridge their own file system
+/// abstraction into TenANN's index writing path.
+class IndexFileWriter {
+ public:
+  virtual ~IndexFileWriter() = default;
+
+  /// Write |count| bytes from |data| to the file.
+  /// Returns the number of bytes actually written, or -1 on error.
+  virtual int64_t Write(const void* data, int64_t count) = 0;
+
+  /// Flush buffered data to the underlying storage.
+  virtual void Flush() = 0;
+
+  /// Close the file. No further writes are allowed after this call.
+  virtual void Close() = 0;
+
+  /// Returns the file name / path (used for logging and identification).
+  virtual const std::string& filename() const = 0;
+};
+
+using IndexFileWriterPtr = std::shared_ptr<IndexFileWriter>;
+
+}  // namespace tenann

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -28,6 +28,8 @@ set(TENANN_TEST_SRC
     searcher/test_range_search.cc
     store/test_index_meta.cc
     store/test_lru_cache.cc
+    store/test_index_file_reader.cc
+    searcher/test_file_reader_search.cc
     thirdparty/test_fmt.cc
     util/test_runtime_profile.cc
     util/test_bruteforce_search.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TENANN_TEST_SRC
     store/test_index_meta.cc
     store/test_lru_cache.cc
     store/test_index_file_reader.cc
+    store/test_index_file_writer.cc
     searcher/test_file_reader_search.cc
     thirdparty/test_fmt.cc
     util/test_runtime_profile.cc

--- a/test/searcher/test_file_reader_search.cc
+++ b/test/searcher/test_file_reader_search.cc
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "tenann/factory/ann_searcher_factory.h"
+#include "tenann/index/parameters.h"
+#include "tenann/store/index_file_reader.h"
+#include "test/faiss_test_base.h"
+
+namespace tenann {
+
+/// A local-file-based IndexFileReader that simulates reading from a remote FS.
+/// Used for end-to-end testing of the IndexFileReader path.
+class TestLocalIndexFileReader : public IndexFileReader {
+ public:
+  explicit TestLocalIndexFileReader(const std::string& path) : filename_(path), position_(0) {
+    fp_ = fopen(path.c_str(), "rb");
+    if (fp_) {
+      fseek(fp_, 0, SEEK_END);
+      file_size_ = ftell(fp_);
+      fseek(fp_, 0, SEEK_SET);
+    } else {
+      file_size_ = 0;
+    }
+  }
+
+  ~TestLocalIndexFileReader() override {
+    if (fp_) fclose(fp_);
+  }
+
+  int64_t Read(void* data, int64_t count) override {
+    if (!fp_) return -1;
+    fseek(fp_, position_, SEEK_SET);
+    size_t n = fread(data, 1, count, fp_);
+    position_ += n;
+    return static_cast<int64_t>(n);
+  }
+
+  int64_t ReadAt(int64_t offset, void* data, int64_t count) override {
+    if (!fp_) return -1;
+    fseek(fp_, offset, SEEK_SET);
+    size_t n = fread(data, 1, count, fp_);
+    return static_cast<int64_t>(n);
+  }
+
+  void Seek(int64_t position) override { position_ = position; }
+
+  int64_t GetSize() override { return file_size_; }
+
+  const std::string& filename() const override { return filename_; }
+
+ private:
+  std::string filename_;
+  FILE* fp_ = nullptr;
+  int64_t position_ = 0;
+  int64_t file_size_ = 0;
+};
+
+// ============================================================================
+// HNSW tests via IndexFileReader
+// ============================================================================
+
+class FaissHnswFileReaderSearchTest : public FaissTestBase {
+ public:
+  FaissHnswFileReaderSearchTest() : FaissTestBase() {
+    InitFaissHnswMeta();
+    faiss_hnsw_index_builder_ = IndexFactory::CreateBuilderFromMeta(faiss_hnsw_meta_);
+  }
+};
+
+TEST_F(FaissHnswFileReaderSearchTest, ReadIndex_ViaFileReader) {
+  // Build and write HNSW index to disk using the normal path
+  CreateAndWriteFaissHnswIndex(false);
+
+  // Now read it back via IndexFileReader
+  auto file_reader =
+      std::make_shared<TestLocalIndexFileReader>(index_with_primary_key_path());
+
+  auto ann_searcher = AnnSearcherFactory::CreateSearcherFromMeta(meta_);
+  ann_searcher->ReadIndex(file_reader);
+
+  EXPECT_TRUE(ann_searcher->is_index_loaded());
+
+  // Search and check recall
+  result_ids_.resize(nq_ * k_);
+  for (int i = 0; i < nq_; i++) {
+    ann_searcher->AnnSearch(query_view_[i], k_, result_ids_.data() + i * k_);
+  }
+  EXPECT_TRUE(RecallCheckResult_80Percent());
+}
+
+TEST_F(FaissHnswFileReaderSearchTest, ReadIndex_ViaFileReader_WithCustomRowId) {
+  CreateAndWriteFaissHnswIndex(true);
+
+  auto file_reader =
+      std::make_shared<TestLocalIndexFileReader>(index_with_primary_key_path());
+
+  auto ann_searcher = AnnSearcherFactory::CreateSearcherFromMeta(meta_);
+  ann_searcher->ReadIndex(file_reader);
+
+  EXPECT_TRUE(ann_searcher->is_index_loaded());
+
+  result_ids_.resize(nq_ * k_);
+  for (int i = 0; i < nq_; i++) {
+    ann_searcher->AnnSearch(query_view_[i], k_, result_ids_.data() + i * k_);
+  }
+  EXPECT_TRUE(RecallCheckResult_80Percent());
+}
+
+// ============================================================================
+// IVFPQ tests via IndexFileReader
+// ============================================================================
+
+class FaissIvfPqFileReaderSearchTest : public FaissTestBase {
+ public:
+  FaissIvfPqFileReaderSearchTest() : FaissTestBase() {
+    InitFaissIvfPqMeta();
+    faiss_ivf_pq_index_builder_ = IndexFactory::CreateBuilderFromMeta(faiss_ivf_pq_meta_);
+  }
+};
+
+TEST_F(FaissIvfPqFileReaderSearchTest, ReadIndex_ViaFileReader) {
+  // Build IVFPQ index
+  CreateAndWriteFaissIvfPqIndex(false);
+
+  // Read via IndexFileReader
+  auto file_reader =
+      std::make_shared<TestLocalIndexFileReader>(index_with_primary_key_path());
+
+  auto ann_searcher = AnnSearcherFactory::CreateSearcherFromMeta(meta_);
+  ann_searcher->ReadIndex(file_reader);
+
+  EXPECT_TRUE(ann_searcher->is_index_loaded());
+
+  result_ids_.resize(nq_ * k_);
+  for (int i = 0; i < nq_; i++) {
+    ann_searcher->AnnSearch(query_view_[i], k_, result_ids_.data() + i * k_);
+  }
+  EXPECT_TRUE(RecallCheckResult_80Percent());
+}
+
+TEST_F(FaissIvfPqFileReaderSearchTest, ReadIndex_ViaFileReader_WithCustomRowId) {
+  CreateAndWriteFaissIvfPqIndex(true);
+
+  auto file_reader =
+      std::make_shared<TestLocalIndexFileReader>(index_with_primary_key_path());
+
+  auto ann_searcher = AnnSearcherFactory::CreateSearcherFromMeta(meta_);
+  ann_searcher->ReadIndex(file_reader);
+
+  EXPECT_TRUE(ann_searcher->is_index_loaded());
+
+  result_ids_.resize(nq_ * k_);
+  for (int i = 0; i < nq_; i++) {
+    ann_searcher->AnnSearch(query_view_[i], k_, result_ids_.data() + i * k_);
+  }
+  EXPECT_TRUE(RecallCheckResult_80Percent());
+}
+
+TEST_F(FaissIvfPqFileReaderSearchTest, ReadIndex_ViaFileReader_BlockCache) {
+  // Enable block cache mode for IVFPQ
+  faiss_ivf_pq_meta_.index_reader_options()["cache_index_block"] = true;
+
+  CreateAndWriteFaissIvfPqIndex(false);
+
+  auto file_reader =
+      std::make_shared<TestLocalIndexFileReader>(index_with_primary_key_path());
+
+  auto ann_searcher = AnnSearcherFactory::CreateSearcherFromMeta(meta_);
+  ann_searcher->index_reader()->index_cache()->SetCapacity(500 * 1024);  // limit 500KB
+  ann_searcher->ReadIndex(file_reader);
+
+  EXPECT_TRUE(ann_searcher->is_index_loaded());
+
+  result_ids_.resize(nq_ * k_);
+  for (int i = 0; i < nq_; i++) {
+    ann_searcher->AnnSearch(query_view_[i], k_, result_ids_.data() + i * k_);
+  }
+  EXPECT_TRUE(RecallCheckResult_80Percent());
+}
+
+TEST_F(FaissIvfPqFileReaderSearchTest, ReadIndex_ViaFileReader_MultiAdd) {
+  MultiAddCreateAndWriteFaissIvfPqIndex();
+
+  auto file_reader =
+      std::make_shared<TestLocalIndexFileReader>(index_with_primary_key_path());
+
+  auto ann_searcher = AnnSearcherFactory::CreateSearcherFromMeta(meta_);
+  ann_searcher->ReadIndex(file_reader);
+
+  EXPECT_TRUE(ann_searcher->is_index_loaded());
+
+  result_ids_.resize(nq_ * k_);
+  for (int i = 0; i < nq_; i++) {
+    ann_searcher->AnnSearch(query_view_[i], k_, result_ids_.data() + i * k_);
+  }
+  EXPECT_TRUE(RecallCheckResult_80Percent());
+}
+
+}  // namespace tenann

--- a/test/store/test_index_file_reader.cc
+++ b/test/store/test_index_file_reader.cc
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "gtest/gtest.h"
-#include "tenann/index/custom_io_reader.h"
+#include "tenann/index/faiss_io_reader_adapter.h"
 #include "tenann/store/index_file_reader.h"
 
 namespace tenann {
@@ -165,9 +165,9 @@ TEST_F(IndexFileReaderTest, LocalFileReader_ReadPastEnd) {
   EXPECT_EQ(n, 24);
 }
 
-TEST_F(IndexFileReaderTest, CustomFaissIOReader_Basic) {
+TEST_F(IndexFileReaderTest, FaissIOReaderAdapter_Basic) {
   auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
-  CustomFaissIOReader io_reader(file_reader);
+  FaissIOReaderAdapter io_reader(file_reader);
 
   EXPECT_EQ(io_reader.name, test_file_);
   EXPECT_EQ(io_reader.bytes_read(), 0u);
@@ -180,9 +180,9 @@ TEST_F(IndexFileReaderTest, CustomFaissIOReader_Basic) {
   EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 32), 0);
 }
 
-TEST_F(IndexFileReaderTest, CustomFaissIOReader_PartialRead) {
+TEST_F(IndexFileReaderTest, FaissIOReaderAdapter_PartialRead) {
   auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
-  CustomFaissIOReader io_reader(file_reader);
+  FaissIOReaderAdapter io_reader(file_reader);
 
   // Read 100 items of 1 byte
   std::vector<uint8_t> buf(100);
@@ -197,9 +197,9 @@ TEST_F(IndexFileReaderTest, CustomFaissIOReader_PartialRead) {
   EXPECT_EQ(memcmp(buf.data(), test_data_.data() + 100, 100), 0);
 }
 
-TEST_F(IndexFileReaderTest, CustomFaissIOReader_ReadPastEnd) {
+TEST_F(IndexFileReaderTest, FaissIOReaderAdapter_ReadPastEnd) {
   auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
-  CustomFaissIOReader io_reader(file_reader);
+  FaissIOReaderAdapter io_reader(file_reader);
 
   // Try to read 200 items of 8 bytes (1600 bytes > 1024)
   std::vector<uint8_t> buf(1600, 0);
@@ -209,9 +209,9 @@ TEST_F(IndexFileReaderTest, CustomFaissIOReader_ReadPastEnd) {
   EXPECT_EQ(io_reader.bytes_read(), 1024u);
 }
 
-TEST_F(IndexFileReaderTest, CustomFaissIOReader_BytesReadTracking) {
+TEST_F(IndexFileReaderTest, FaissIOReaderAdapter_BytesReadTracking) {
   auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
-  CustomFaissIOReader io_reader(file_reader);
+  FaissIOReaderAdapter io_reader(file_reader);
 
   std::vector<uint8_t> buf(256);
   io_reader(buf.data(), 1, 50);

--- a/test/store/test_index_file_reader.cc
+++ b/test/store/test_index_file_reader.cc
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tenann/index/custom_io_reader.h"
+#include "tenann/store/index_file_reader.h"
+
+namespace tenann {
+
+/// A local-file-based IndexFileReader for testing purposes.
+/// Wraps POSIX FILE* to simulate reading from any file system.
+class LocalIndexFileReader : public IndexFileReader {
+ public:
+  explicit LocalIndexFileReader(const std::string& path) : filename_(path), position_(0) {
+    fp_ = fopen(path.c_str(), "rb");
+    if (fp_) {
+      fseek(fp_, 0, SEEK_END);
+      file_size_ = ftell(fp_);
+      fseek(fp_, 0, SEEK_SET);
+    } else {
+      file_size_ = 0;
+    }
+  }
+
+  ~LocalIndexFileReader() override {
+    if (fp_) fclose(fp_);
+  }
+
+  int64_t Read(void* data, int64_t count) override {
+    if (!fp_) return -1;
+    fseek(fp_, position_, SEEK_SET);
+    size_t n = fread(data, 1, count, fp_);
+    position_ += n;
+    return static_cast<int64_t>(n);
+  }
+
+  int64_t ReadAt(int64_t offset, void* data, int64_t count) override {
+    if (!fp_) return -1;
+    fseek(fp_, offset, SEEK_SET);
+    size_t n = fread(data, 1, count, fp_);
+    // ReadAt should not change position_
+    return static_cast<int64_t>(n);
+  }
+
+  void Seek(int64_t position) override { position_ = position; }
+
+  int64_t GetSize() override { return file_size_; }
+
+  const std::string& filename() const override { return filename_; }
+
+  bool is_open() const { return fp_ != nullptr; }
+
+ private:
+  std::string filename_;
+  FILE* fp_ = nullptr;
+  int64_t position_ = 0;
+  int64_t file_size_ = 0;
+};
+
+class IndexFileReaderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    test_file_ = "/tmp/tenann_test_index_file_reader.bin";
+    // Write test data to file
+    test_data_.resize(1024);
+    for (size_t i = 0; i < test_data_.size(); i++) {
+      test_data_[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+    FILE* fp = fopen(test_file_.c_str(), "wb");
+    ASSERT_NE(fp, nullptr);
+    fwrite(test_data_.data(), 1, test_data_.size(), fp);
+    fclose(fp);
+  }
+
+  void TearDown() override { std::remove(test_file_.c_str()); }
+
+  std::string test_file_;
+  std::vector<uint8_t> test_data_;
+};
+
+TEST_F(IndexFileReaderTest, LocalFileReader_Open) {
+  auto reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  EXPECT_TRUE(reader->is_open());
+  EXPECT_EQ(reader->GetSize(), 1024);
+  EXPECT_EQ(reader->filename(), test_file_);
+}
+
+TEST_F(IndexFileReaderTest, LocalFileReader_OpenFail) {
+  auto reader = std::make_shared<LocalIndexFileReader>("/tmp/non_existent_file_xxx.bin");
+  EXPECT_FALSE(reader->is_open());
+  EXPECT_EQ(reader->GetSize(), 0);
+}
+
+TEST_F(IndexFileReaderTest, LocalFileReader_SequentialRead) {
+  auto reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  // Read first 100 bytes
+  std::vector<uint8_t> buf(100);
+  int64_t n = reader->Read(buf.data(), 100);
+  EXPECT_EQ(n, 100);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 100), 0);
+
+  // Read next 200 bytes
+  buf.resize(200);
+  n = reader->Read(buf.data(), 200);
+  EXPECT_EQ(n, 200);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data() + 100, 200), 0);
+}
+
+TEST_F(IndexFileReaderTest, LocalFileReader_ReadAt) {
+  auto reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  std::vector<uint8_t> buf(50);
+
+  // Read at offset 500
+  int64_t n = reader->ReadAt(500, buf.data(), 50);
+  EXPECT_EQ(n, 50);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data() + 500, 50), 0);
+
+  // ReadAt should not affect sequential position
+  // Sequential read should still start from 0
+  std::vector<uint8_t> buf2(10);
+  n = reader->Read(buf2.data(), 10);
+  EXPECT_EQ(n, 10);
+  EXPECT_EQ(memcmp(buf2.data(), test_data_.data(), 10), 0);
+}
+
+TEST_F(IndexFileReaderTest, LocalFileReader_Seek) {
+  auto reader = std::make_shared<LocalIndexFileReader>(test_file_);
+
+  // Seek to offset 512, then read
+  reader->Seek(512);
+  std::vector<uint8_t> buf(100);
+  int64_t n = reader->Read(buf.data(), 100);
+  EXPECT_EQ(n, 100);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data() + 512, 100), 0);
+}
+
+TEST_F(IndexFileReaderTest, LocalFileReader_ReadPastEnd) {
+  auto reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  reader->Seek(1000);
+  std::vector<uint8_t> buf(100);
+  int64_t n = reader->Read(buf.data(), 100);
+  // Only 24 bytes remaining
+  EXPECT_EQ(n, 24);
+}
+
+TEST_F(IndexFileReaderTest, CustomFaissIOReader_Basic) {
+  auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  CustomFaissIOReader io_reader(file_reader);
+
+  EXPECT_EQ(io_reader.name, test_file_);
+  EXPECT_EQ(io_reader.bytes_read(), 0u);
+
+  // Read 4 items of 8 bytes each (simulating FAISS READ1/READVECTOR)
+  std::vector<uint8_t> buf(32);
+  size_t nitems = io_reader(buf.data(), 8, 4);
+  EXPECT_EQ(nitems, 4u);
+  EXPECT_EQ(io_reader.bytes_read(), 32u);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 32), 0);
+}
+
+TEST_F(IndexFileReaderTest, CustomFaissIOReader_PartialRead) {
+  auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  CustomFaissIOReader io_reader(file_reader);
+
+  // Read 100 items of 1 byte
+  std::vector<uint8_t> buf(100);
+  size_t nitems = io_reader(buf.data(), 1, 100);
+  EXPECT_EQ(nitems, 100u);
+  EXPECT_EQ(io_reader.bytes_read(), 100u);
+
+  // Read more
+  nitems = io_reader(buf.data(), 1, 100);
+  EXPECT_EQ(nitems, 100u);
+  EXPECT_EQ(io_reader.bytes_read(), 200u);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data() + 100, 100), 0);
+}
+
+TEST_F(IndexFileReaderTest, CustomFaissIOReader_ReadPastEnd) {
+  auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  CustomFaissIOReader io_reader(file_reader);
+
+  // Try to read 200 items of 8 bytes (1600 bytes > 1024)
+  std::vector<uint8_t> buf(1600, 0);
+  size_t nitems = io_reader(buf.data(), 8, 200);
+  // Should return 128 complete items (1024 / 8)
+  EXPECT_EQ(nitems, 128u);
+  EXPECT_EQ(io_reader.bytes_read(), 1024u);
+}
+
+TEST_F(IndexFileReaderTest, CustomFaissIOReader_BytesReadTracking) {
+  auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
+  CustomFaissIOReader io_reader(file_reader);
+
+  std::vector<uint8_t> buf(256);
+  io_reader(buf.data(), 1, 50);
+  EXPECT_EQ(io_reader.bytes_read(), 50u);
+
+  io_reader(buf.data(), 4, 25);
+  EXPECT_EQ(io_reader.bytes_read(), 150u);  // 50 + 100
+
+  io_reader(buf.data(), 1, 200);
+  EXPECT_EQ(io_reader.bytes_read(), 350u);  // 150 + 200
+}
+
+}  // namespace tenann

--- a/test/store/test_index_file_writer.cc
+++ b/test/store/test_index_file_writer.cc
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "tenann/index/faiss_io_reader_adapter.h"
+#include "tenann/index/faiss_io_writer_adapter.h"
+#include "tenann/store/index_file_reader.h"
+#include "tenann/store/index_file_writer.h"
+
+namespace tenann {
+
+/// A local-file-based IndexFileWriter for testing purposes.
+/// Wraps POSIX FILE* to simulate writing to any file system.
+class LocalIndexFileWriter : public IndexFileWriter {
+ public:
+  explicit LocalIndexFileWriter(const std::string& path) : filename_(path) {
+    fp_ = fopen(path.c_str(), "wb");
+  }
+
+  ~LocalIndexFileWriter() override {
+    if (fp_) fclose(fp_);
+  }
+
+  int64_t Write(const void* data, int64_t count) override {
+    if (!fp_) return -1;
+    size_t n = fwrite(data, 1, count, fp_);
+    return static_cast<int64_t>(n);
+  }
+
+  void Flush() override {
+    if (fp_) fflush(fp_);
+  }
+
+  void Close() override {
+    if (fp_) {
+      fclose(fp_);
+      fp_ = nullptr;
+    }
+  }
+
+  const std::string& filename() const override { return filename_; }
+
+  bool is_open() const { return fp_ != nullptr; }
+
+ private:
+  std::string filename_;
+  FILE* fp_ = nullptr;
+};
+
+/// A local-file-based IndexFileReader for verifying written data.
+class LocalIndexFileReader : public IndexFileReader {
+ public:
+  explicit LocalIndexFileReader(const std::string& path) : filename_(path), position_(0) {
+    fp_ = fopen(path.c_str(), "rb");
+    if (fp_) {
+      fseek(fp_, 0, SEEK_END);
+      file_size_ = ftell(fp_);
+      fseek(fp_, 0, SEEK_SET);
+    } else {
+      file_size_ = 0;
+    }
+  }
+
+  ~LocalIndexFileReader() override {
+    if (fp_) fclose(fp_);
+  }
+
+  int64_t Read(void* data, int64_t count) override {
+    if (!fp_) return -1;
+    fseek(fp_, position_, SEEK_SET);
+    size_t n = fread(data, 1, count, fp_);
+    position_ += n;
+    return static_cast<int64_t>(n);
+  }
+
+  int64_t ReadAt(int64_t offset, void* data, int64_t count) override {
+    if (!fp_) return -1;
+    fseek(fp_, offset, SEEK_SET);
+    return static_cast<int64_t>(fread(data, 1, count, fp_));
+  }
+
+  void Seek(int64_t position) override { position_ = position; }
+  int64_t GetSize() override { return file_size_; }
+  const std::string& filename() const override { return filename_; }
+
+ private:
+  std::string filename_;
+  FILE* fp_ = nullptr;
+  int64_t position_ = 0;
+  int64_t file_size_ = 0;
+};
+
+class IndexFileWriterTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    test_file_ = "/tmp/tenann_test_index_file_writer.bin";
+    // Prepare test data
+    test_data_.resize(1024);
+    for (size_t i = 0; i < test_data_.size(); i++) {
+      test_data_[i] = static_cast<uint8_t>(i & 0xFF);
+    }
+  }
+
+  void TearDown() override { std::remove(test_file_.c_str()); }
+
+  std::string test_file_;
+  std::vector<uint8_t> test_data_;
+};
+
+TEST_F(IndexFileWriterTest, LocalFileWriter_Open) {
+  auto writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+  EXPECT_TRUE(writer->is_open());
+  EXPECT_EQ(writer->filename(), test_file_);
+}
+
+TEST_F(IndexFileWriterTest, LocalFileWriter_OpenFail) {
+  auto writer = std::make_shared<LocalIndexFileWriter>("/nonexistent_dir/file.bin");
+  EXPECT_FALSE(writer->is_open());
+}
+
+TEST_F(IndexFileWriterTest, LocalFileWriter_Write) {
+  {
+    auto writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+    int64_t n = writer->Write(test_data_.data(), test_data_.size());
+    EXPECT_EQ(n, 1024);
+    writer->Close();
+  }
+
+  // Verify written content
+  std::vector<uint8_t> buf(1024);
+  FILE* fp = fopen(test_file_.c_str(), "rb");
+  ASSERT_NE(fp, nullptr);
+  size_t read = fread(buf.data(), 1, 1024, fp);
+  fclose(fp);
+  EXPECT_EQ(read, 1024u);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 1024), 0);
+}
+
+TEST_F(IndexFileWriterTest, LocalFileWriter_MultipleWrites) {
+  {
+    auto writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+    // Write in chunks
+    int64_t n1 = writer->Write(test_data_.data(), 100);
+    int64_t n2 = writer->Write(test_data_.data() + 100, 200);
+    int64_t n3 = writer->Write(test_data_.data() + 300, 724);
+    EXPECT_EQ(n1, 100);
+    EXPECT_EQ(n2, 200);
+    EXPECT_EQ(n3, 724);
+    writer->Close();
+  }
+
+  // Verify written content
+  std::vector<uint8_t> buf(1024);
+  FILE* fp = fopen(test_file_.c_str(), "rb");
+  ASSERT_NE(fp, nullptr);
+  size_t nread = fread(buf.data(), 1, 1024, fp);
+  fclose(fp);
+  EXPECT_EQ(nread, 1024u);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 1024), 0);
+}
+
+TEST_F(IndexFileWriterTest, LocalFileWriter_Flush) {
+  auto writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+  writer->Write(test_data_.data(), 512);
+  writer->Flush();
+
+  // File should be readable after flush (data flushed to disk)
+  FILE* fp = fopen(test_file_.c_str(), "rb");
+  ASSERT_NE(fp, nullptr);
+  fseek(fp, 0, SEEK_END);
+  long size = ftell(fp);
+  fclose(fp);
+  EXPECT_EQ(size, 512);
+}
+
+TEST_F(IndexFileWriterTest, LocalFileWriter_Close) {
+  auto writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+  EXPECT_TRUE(writer->is_open());
+  writer->Write(test_data_.data(), 100);
+  writer->Close();
+  EXPECT_FALSE(writer->is_open());
+
+  // Write after close should return -1
+  int64_t n = writer->Write(test_data_.data(), 100);
+  EXPECT_EQ(n, -1);
+}
+
+TEST_F(IndexFileWriterTest, FaissIOWriterAdapter_Basic) {
+  auto file_writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+  FaissIOWriterAdapter adapter(file_writer);
+
+  EXPECT_EQ(adapter.name, test_file_);
+
+  // Write 4 items of 8 bytes each (simulating FAISS WRITE1/WRITEVECTOR)
+  size_t nitems = adapter(test_data_.data(), 8, 4);
+  EXPECT_EQ(nitems, 4u);
+  file_writer->Close();
+
+  // Verify written content
+  std::vector<uint8_t> buf(32);
+  FILE* fp = fopen(test_file_.c_str(), "rb");
+  ASSERT_NE(fp, nullptr);
+  size_t nread = fread(buf.data(), 1, 32, fp);
+  fclose(fp);
+  EXPECT_EQ(nread, 32u);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 32), 0);
+}
+
+TEST_F(IndexFileWriterTest, FaissIOWriterAdapter_MultipleWrites) {
+  auto file_writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+  FaissIOWriterAdapter adapter(file_writer);
+
+  // Write 100 items of 1 byte
+  size_t n1 = adapter(test_data_.data(), 1, 100);
+  EXPECT_EQ(n1, 100u);
+
+  // Write 25 items of 4 bytes
+  size_t n2 = adapter(test_data_.data() + 100, 4, 25);
+  EXPECT_EQ(n2, 25u);
+
+  // Write 50 items of 1 byte
+  size_t n3 = adapter(test_data_.data() + 200, 1, 50);
+  EXPECT_EQ(n3, 50u);
+
+  file_writer->Close();
+
+  // Verify: total 250 bytes written
+  std::vector<uint8_t> buf(250);
+  FILE* fp = fopen(test_file_.c_str(), "rb");
+  ASSERT_NE(fp, nullptr);
+  size_t nread = fread(buf.data(), 1, 250, fp);
+  fclose(fp);
+  EXPECT_EQ(nread, 250u);
+  EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 250), 0);
+}
+
+TEST_F(IndexFileWriterTest, FaissIOWriterAdapter_WriteThenRead) {
+  // Write via FaissIOWriterAdapter
+  {
+    auto file_writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+    FaissIOWriterAdapter writer_adapter(file_writer);
+
+    writer_adapter(test_data_.data(), 1, test_data_.size());
+    file_writer->Close();
+  }
+
+  // Read back via FaissIOReaderAdapter and verify round-trip
+  {
+    auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
+    EXPECT_EQ(file_reader->GetSize(), 1024);
+
+    FaissIOReaderAdapter reader_adapter(file_reader);
+    std::vector<uint8_t> buf(1024);
+    size_t nitems = reader_adapter(buf.data(), 1, 1024);
+    EXPECT_EQ(nitems, 1024u);
+    EXPECT_EQ(memcmp(buf.data(), test_data_.data(), 1024), 0);
+  }
+}
+
+TEST_F(IndexFileWriterTest, FaissIOWriterAdapter_LargeWrite) {
+  // Write large data (64KB)
+  std::vector<uint8_t> large_data(65536);
+  for (size_t i = 0; i < large_data.size(); i++) {
+    large_data[i] = static_cast<uint8_t>((i * 7 + 13) & 0xFF);
+  }
+
+  {
+    auto file_writer = std::make_shared<LocalIndexFileWriter>(test_file_);
+    FaissIOWriterAdapter adapter(file_writer);
+    // Write as 8192 items of 8 bytes
+    size_t nitems = adapter(large_data.data(), 8, 8192);
+    EXPECT_EQ(nitems, 8192u);
+    file_writer->Close();
+  }
+
+  // Verify
+  {
+    auto file_reader = std::make_shared<LocalIndexFileReader>(test_file_);
+    EXPECT_EQ(file_reader->GetSize(), 65536);
+    std::vector<uint8_t> buf(65536);
+    file_reader->Read(buf.data(), 65536);
+    EXPECT_EQ(memcmp(buf.data(), large_data.data(), 65536), 0);
+  }
+}
+
+}  // namespace tenann


### PR DESCRIPTION
  ## Why I'm doing:

  TenANN's index read/write paths currently rely on POSIX file I/O (fopen/fread/mmap, etc.) and cannot operate on remote file systems
  (S3, HDFS, OSS, etc.). This is a prerequisite for supporting vector index in StarRocks shared-data mode.

  ## What I'm doing:

  Introduce abstract file I/O interfaces so that TenANN can read and write index files on arbitrary file systems via externally
  injected reader/writer implementations.

  Read path (commit 0a914ac)

  - Add IndexFileReader abstract interface (tenann/store/index_file_reader.h) with Read/ReadAt/Seek/GetSize methods
  - Add FaissIOReaderAdapter to bridge IndexFileReader to faiss::IOReader
  - Add SetFileReader() to IndexReader; FaissIndexReader and IndexIvfPqReader read through the adapter when file_reader_ is set
  - BlockCacheInvertedLists supports random-access reads via IndexFileReader for remote inverted list data
  - Add Searcher::ReadIndex(IndexFileReaderPtr) overload

  Write path (commit 0d19aa8)

  - Add IndexFileWriter abstract interface (tenann/store/index_file_writer.h) with Write/Flush/Close methods
  - Add FaissIOWriterAdapter to bridge IndexFileWriter to faiss::IOWriter
  - Add SetFileWriter() to IndexWriter; FaissIndexWriter writes through the adapter when file_writer_ is set
  - Refactor IndexIvfPqWriter into WriteIndexFile() + WriteIndexContent() to support writing via adapter
  - Add IndexBuilder::SetFileWriter() that passes through to the internal writer

  Tests

  - Add test_index_file_reader.cc: IndexFileReader interface tests + FaissIOReaderAdapter tests (10 cases)
  - Add test_index_file_writer.cc: IndexFileWriter interface tests + FaissIOWriterAdapter tests + read-write round-trip test (10 cases)
  - Add test_file_reader_search.cc: end-to-end ANN search tests reading index via FileReader