### PR TITLE
[Enhancement] Add read-path timing statistics to IndexReader

### DIFF
--- a/tenann/index/faiss_index_reader.cc
+++ b/tenann/index/faiss_index_reader.cc
@@ -24,6 +24,7 @@
 #include "faiss/index_io.h"
 #include "tenann/common/logging.h"
 #include "tenann/index/faiss_io_reader_adapter.h"
+#include "tenann/util/stop_watch.h"
 
 namespace tenann {
 
@@ -33,14 +34,23 @@ IndexRef FaissIndexReader::ReadIndexFile(const std::string& path) {
   try {
     faiss::Index* raw_index = nullptr;
 
+    MonotonicStopWatch total_sw;
+    total_sw.start();
     if (file_reader_) {
       // Use external file reader (for remote file systems).
       // Cannot use MMAP with remote FS, use IO_FLAG_READ_ONLY instead.
       FaissIOReaderAdapter io_reader(file_reader_);
       raw_index = faiss::read_index(&io_reader, faiss::IO_FLAG_READ_ONLY);
+      total_sw.stop();
+      // io_reader tracks cumulative I/O time inside Read() calls
+      read_timing_stats_.read_file_ns += io_reader.io_time_ns();
+      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - io_reader.io_time_ns();
     } else {
       // Local file path: use MMAP for best performance.
+      // MMAP makes disk I/O lazy (page faults), so we report total time as read_file_ns.
       raw_index = faiss::read_index(path.c_str(), faiss::IO_FLAG_MMAP);
+      total_sw.stop();
+      read_timing_stats_.read_file_ns += total_sw.elapsed_time();
     }
 
     return std::make_shared<Index>(raw_index,  //

--- a/tenann/index/faiss_index_reader.cc
+++ b/tenann/index/faiss_index_reader.cc
@@ -19,6 +19,8 @@
 
 #include "tenann/index/faiss_index_reader.h"
 
+#include <algorithm>
+
 #include "faiss/Index.h"
 #include "faiss/impl/FaissException.h"
 #include "faiss/index_io.h"
@@ -42,15 +44,19 @@ IndexRef FaissIndexReader::ReadIndexFile(const std::string& path) {
       FaissIOReaderAdapter io_reader(file_reader_);
       raw_index = faiss::read_index(&io_reader, faiss::IO_FLAG_READ_ONLY);
       total_sw.stop();
-      // io_reader tracks cumulative I/O time inside Read() calls
-      read_timing_stats_.read_file_ns += io_reader.io_time_ns();
-      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - io_reader.io_time_ns();
+      // io_reader tracks cumulative I/O time inside Read() calls.
+      // Subtract in signed int64_t and clamp at 0: per-call stopwatch overhead
+      // can push io_time_ns slightly above total_sw.elapsed_time().
+      const int64_t total_ns = static_cast<int64_t>(total_sw.elapsed_time());
+      const int64_t io_ns = static_cast<int64_t>(io_reader.io_time_ns());
+      read_timing_stats_.read_file_ns += io_ns;
+      read_timing_stats_.init_index_ns += std::max<int64_t>(0, total_ns - io_ns);
     } else {
       // Local file path: use MMAP for best performance.
       // MMAP makes disk I/O lazy (page faults), so we report total time as read_file_ns.
       raw_index = faiss::read_index(path.c_str(), faiss::IO_FLAG_MMAP);
       total_sw.stop();
-      read_timing_stats_.read_file_ns += total_sw.elapsed_time();
+      read_timing_stats_.read_file_ns += static_cast<int64_t>(total_sw.elapsed_time());
     }
 
     return std::make_shared<Index>(raw_index,  //

--- a/tenann/index/faiss_io_reader_adapter.h
+++ b/tenann/index/faiss_io_reader_adapter.h
@@ -56,13 +56,13 @@ class FaissIOReaderAdapter : public faiss::IOReader {
   size_t bytes_read() const { return bytes_read_; }
 
   /// Returns cumulative I/O time in nanoseconds.
-  int64_t io_time_ns() const { return io_time_ns_; }
+  uint64_t io_time_ns() const { return io_time_ns_; }
 
   IndexFileReaderPtr reader_;
 
  private:
   size_t bytes_read_;
-  int64_t io_time_ns_;
+  uint64_t io_time_ns_;
 };
 
 }  // namespace tenann

--- a/tenann/index/faiss_io_reader_adapter.h
+++ b/tenann/index/faiss_io_reader_adapter.h
@@ -24,6 +24,7 @@
 
 #include "faiss/impl/io.h"
 #include "tenann/store/index_file_reader.h"
+#include "tenann/util/stop_watch.h"
 
 namespace tenann {
 
@@ -31,7 +32,8 @@ namespace tenann {
 /// IndexFileReader, allowing FAISS to read from remote file systems.
 class FaissIOReaderAdapter : public faiss::IOReader {
  public:
-  explicit FaissIOReaderAdapter(IndexFileReaderPtr reader) : reader_(std::move(reader)), bytes_read_(0) {
+  explicit FaissIOReaderAdapter(IndexFileReaderPtr reader)
+      : reader_(std::move(reader)), bytes_read_(0), io_time_ns_(0) {
     name = reader_->filename();
   }
 
@@ -39,7 +41,11 @@ class FaissIOReaderAdapter : public faiss::IOReader {
   /// Semantics match fread(): returns number of complete items read.
   size_t operator()(void* ptr, size_t size, size_t nitems) override {
     int64_t total = static_cast<int64_t>(size) * static_cast<int64_t>(nitems);
+    MonotonicStopWatch sw;
+    sw.start();
     int64_t n = reader_->Read(ptr, total);
+    sw.stop();
+    io_time_ns_ += sw.elapsed_time();
     if (n <= 0) return 0;
     bytes_read_ += static_cast<size_t>(n);
     return static_cast<size_t>(n) / size;
@@ -49,10 +55,14 @@ class FaissIOReaderAdapter : public faiss::IOReader {
   /// Used to determine the file offset at which inverted lists data starts.
   size_t bytes_read() const { return bytes_read_; }
 
+  /// Returns cumulative I/O time in nanoseconds.
+  int64_t io_time_ns() const { return io_time_ns_; }
+
   IndexFileReaderPtr reader_;
 
  private:
   size_t bytes_read_;
+  int64_t io_time_ns_;
 };
 
 }  // namespace tenann

--- a/tenann/index/index_ivfpq_reader.cc
+++ b/tenann/index/index_ivfpq_reader.cc
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 
@@ -514,8 +515,11 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
       }
 
       total_sw.stop();
-      read_timing_stats_.init_index_ns += precompute_ns;
-      read_timing_stats_.read_file_ns += total_sw.elapsed_time() - precompute_ns;
+      {
+        const int64_t total_ns = static_cast<int64_t>(total_sw.elapsed_time());
+        read_timing_stats_.init_index_ns += precompute_ns;
+        read_timing_stats_.read_file_ns += std::max<int64_t>(0, total_ns - precompute_ns);
+      }
 
       return std::make_shared<Index>(index_ivfpq.release(),   //
                                      IndexType::kFaissIvfPq,  //
@@ -547,8 +551,11 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
       index_pt->index = index_ivfpq.release();
 
       total_sw.stop();
-      read_timing_stats_.init_index_ns += precompute_ns;
-      read_timing_stats_.read_file_ns += total_sw.elapsed_time() - precompute_ns;
+      {
+        const int64_t total_ns = static_cast<int64_t>(total_sw.elapsed_time());
+        read_timing_stats_.init_index_ns += precompute_ns;
+        read_timing_stats_.read_file_ns += std::max<int64_t>(0, total_ns - precompute_ns);
+      }
 
       return std::make_shared<Index>(
           index_pt.release(),      //
@@ -558,7 +565,7 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
       T_LOG(INFO) << "Unknow index to tenann::reader. using faiss::reader";
 
       total_sw.stop();
-      read_timing_stats_.read_file_ns += total_sw.elapsed_time();
+      read_timing_stats_.read_file_ns += static_cast<int64_t>(total_sw.elapsed_time());
 
       return std::make_shared<Index>(faiss::read_index(f, IO_FLAG),  //
                                      IndexType::kFaissIvfPq,         //
@@ -600,9 +607,15 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
       }
 
       total_sw.stop();
-      // I/O time from adapter captures actual remote read time
-      read_timing_stats_.read_file_ns += reader.io_time_ns();
-      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - reader.io_time_ns();
+      {
+        // I/O time from adapter captures actual remote read time.
+        // Subtract in signed int64_t and clamp at 0: per-call stopwatch overhead
+        // can push io_time_ns slightly above total_sw.elapsed_time().
+        const int64_t total_ns = static_cast<int64_t>(total_sw.elapsed_time());
+        const int64_t io_ns = static_cast<int64_t>(reader.io_time_ns());
+        read_timing_stats_.read_file_ns += io_ns;
+        read_timing_stats_.init_index_ns += std::max<int64_t>(0, total_ns - io_ns);
+      }
 
       return std::make_shared<Index>(index_ivfpq.release(),   //
                                      IndexType::kFaissIvfPq,  //
@@ -631,8 +644,12 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
       index_pt->index = index_ivfpq.release();
 
       total_sw.stop();
-      read_timing_stats_.read_file_ns += reader.io_time_ns();
-      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - reader.io_time_ns();
+      {
+        const int64_t total_ns = static_cast<int64_t>(total_sw.elapsed_time());
+        const int64_t io_ns = static_cast<int64_t>(reader.io_time_ns());
+        read_timing_stats_.read_file_ns += io_ns;
+        read_timing_stats_.init_index_ns += std::max<int64_t>(0, total_ns - io_ns);
+      }
 
       return std::make_shared<Index>(
           index_pt.release(),      //
@@ -642,8 +659,12 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
       T_LOG(INFO) << "Unknow index to tenann::reader. using faiss::reader";
 
       total_sw.stop();
-      read_timing_stats_.read_file_ns += reader.io_time_ns();
-      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - reader.io_time_ns();
+      {
+        const int64_t total_ns = static_cast<int64_t>(total_sw.elapsed_time());
+        const int64_t io_ns = static_cast<int64_t>(reader.io_time_ns());
+        read_timing_stats_.read_file_ns += io_ns;
+        read_timing_stats_.init_index_ns += std::max<int64_t>(0, total_ns - io_ns);
+      }
 
       return std::make_shared<Index>(faiss::read_index(f, IO_FLAG),  //
                                      IndexType::kFaissIvfPq,         //

--- a/tenann/index/index_ivfpq_reader.cc
+++ b/tenann/index/index_ivfpq_reader.cc
@@ -42,6 +42,7 @@
 #include "tenann/index/faiss_io_reader_adapter.h"
 #include "tenann/index/internal/index_ivfpq.h"
 #include "tenann/util/defer.h"
+#include "tenann/util/stop_watch.h"
 
 namespace faiss {
 
@@ -189,7 +190,8 @@ static void read_ProductQuantizer(ProductQuantizer* pq, IOReader* f) {
 
 static void read_ivfpq(IndexIVFPQ* ivpq, IOReader* f, uint32_t h, int io_flags,
                        bool cache_index_block, tenann::IndexCache* index_cache,
-                       tenann::IndexFileReaderPtr file_reader = nullptr) {
+                       tenann::IndexFileReaderPtr file_reader = nullptr,
+                       int64_t* precompute_table_ns = nullptr) {
   bool legacy = h == fourcc("IvQR") || h == fourcc("IvPQ");
 
   std::vector<std::vector<idx_t>> ids;
@@ -211,7 +213,13 @@ static void read_ivfpq(IndexIVFPQ* ivpq, IOReader* f, uint32_t h, int io_flags,
     ivpq->use_precomputed_table = 0;
     if (ivpq->by_residual) {
       if ((io_flags & IO_FLAG_SKIP_PRECOMPUTE_TABLE) == 0) {
+        tenann::MonotonicStopWatch sw;
+        sw.start();
         ivpq->precompute_table();
+        sw.stop();
+        if (precompute_table_ns) {
+          *precompute_table_ns = sw.elapsed_time();
+        }
       }
     }
   }
@@ -461,6 +469,9 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
   }
 
   // ---- Local file system path: original fopen logic ----
+  MonotonicStopWatch total_sw;
+  total_sw.start();
+
   auto file = fopen(path.c_str(), "rb");
   Defer defer([file]() {
     if (file != nullptr) fclose(file);
@@ -477,6 +488,8 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
     // the name `f` is needed for faiss IO macros
     auto* f = &reader;
 
+    int64_t precompute_ns = 0;
+
     // read header
     uint32_t h;
     READ1(h);
@@ -488,7 +501,7 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
       // read faiss IndexIVFPQ
       VLOG(VERBOSE_DEBUG) << "cache_index_block: " << index_reader_options_.cache_index_block;
       faiss::read_ivfpq(index_ivfpq.get(), f, h, IO_FLAG, index_reader_options_.cache_index_block,
-                        index_cache());
+                        index_cache(), nullptr, &precompute_ns);
       /* read custom fields */
       // read range_search_confidence
       READ1(index_ivfpq->range_search_confidence);
@@ -499,6 +512,10 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
       for (size_t i = 0; i < num_invlists; i++) {
         READVECTOR(index_ivfpq->reconstruction_errors[i]);
       }
+
+      total_sw.stop();
+      read_timing_stats_.init_index_ns += precompute_ns;
+      read_timing_stats_.read_file_ns += total_sw.elapsed_time() - precompute_ns;
 
       return std::make_shared<Index>(index_ivfpq.release(),   //
                                      IndexType::kFaissIvfPq,  //
@@ -516,7 +533,7 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
       READ1(h);
       VLOG(VERBOSE_DEBUG) << "cache_index_block: " << index_reader_options_.cache_index_block;
       faiss::read_ivfpq(index_ivfpq.get(), f, h, IO_FLAG, index_reader_options_.cache_index_block,
-                        index_cache());
+                        index_cache(), nullptr, &precompute_ns);
       /* read custom fields */
       // read range_search_confidence
       READ1(index_ivfpq->range_search_confidence);
@@ -528,12 +545,21 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
         READVECTOR(index_ivfpq->reconstruction_errors[i]);
       }
       index_pt->index = index_ivfpq.release();
+
+      total_sw.stop();
+      read_timing_stats_.init_index_ns += precompute_ns;
+      read_timing_stats_.read_file_ns += total_sw.elapsed_time() - precompute_ns;
+
       return std::make_shared<Index>(
           index_pt.release(),      //
           IndexType::kFaissIvfPq,  //
           [](void* index) { delete static_cast<faiss::IndexPreTransform*>(index); });
     } else {
       T_LOG(INFO) << "Unknow index to tenann::reader. using faiss::reader";
+
+      total_sw.stop();
+      read_timing_stats_.read_file_ns += total_sw.elapsed_time();
+
       return std::make_shared<Index>(faiss::read_index(f, IO_FLAG),  //
                                      IndexType::kFaissIvfPq,         //
                                      [](void* index) { delete static_cast<faiss::Index*>(index); });
@@ -546,9 +572,14 @@ IndexRef IndexIvfPqReader::ReadIndexFile(const std::string& path) {
 }
 
 IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
+  MonotonicStopWatch total_sw;
+  total_sw.start();
+
   try {
     FaissIOReaderAdapter reader(file_reader_);
     auto* f = &reader;
+
+    int64_t precompute_ns = 0;
 
     uint32_t h;
     READ1(h);
@@ -559,7 +590,7 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
       auto index_ivfpq = std::make_unique<IndexIvfPq>();
       VLOG(VERBOSE_DEBUG) << "cache_index_block: " << index_reader_options_.cache_index_block;
       faiss::read_ivfpq(index_ivfpq.get(), f, h, IO_FLAG, index_reader_options_.cache_index_block,
-                        index_cache(), file_reader_);
+                        index_cache(), file_reader_, &precompute_ns);
       READ1(index_ivfpq->range_search_confidence);
       size_t num_invlists;
       READ1(num_invlists);
@@ -567,6 +598,12 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
       for (size_t i = 0; i < num_invlists; i++) {
         READVECTOR(index_ivfpq->reconstruction_errors[i]);
       }
+
+      total_sw.stop();
+      // I/O time from adapter captures actual remote read time
+      read_timing_stats_.read_file_ns += reader.io_time_ns();
+      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - reader.io_time_ns();
+
       return std::make_shared<Index>(index_ivfpq.release(),   //
                                      IndexType::kFaissIvfPq,  //
                                      [](void* index) { delete static_cast<faiss::Index*>(index); });
@@ -583,7 +620,7 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
       READ1(h);
       VLOG(VERBOSE_DEBUG) << "cache_index_block: " << index_reader_options_.cache_index_block;
       faiss::read_ivfpq(index_ivfpq.get(), f, h, IO_FLAG, index_reader_options_.cache_index_block,
-                        index_cache(), file_reader_);
+                        index_cache(), file_reader_, &precompute_ns);
       READ1(index_ivfpq->range_search_confidence);
       size_t num_invlists;
       READ1(num_invlists);
@@ -592,12 +629,22 @@ IndexRef IndexIvfPqReader::ReadIndexFileFromReader(const std::string& path) {
         READVECTOR(index_ivfpq->reconstruction_errors[i]);
       }
       index_pt->index = index_ivfpq.release();
+
+      total_sw.stop();
+      read_timing_stats_.read_file_ns += reader.io_time_ns();
+      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - reader.io_time_ns();
+
       return std::make_shared<Index>(
           index_pt.release(),      //
           IndexType::kFaissIvfPq,  //
           [](void* index) { delete static_cast<faiss::IndexPreTransform*>(index); });
     } else {
       T_LOG(INFO) << "Unknow index to tenann::reader. using faiss::reader";
+
+      total_sw.stop();
+      read_timing_stats_.read_file_ns += reader.io_time_ns();
+      read_timing_stats_.init_index_ns += total_sw.elapsed_time() - reader.io_time_ns();
+
       return std::make_shared<Index>(faiss::read_index(f, IO_FLAG),  //
                                      IndexType::kFaissIvfPq,         //
                                      [](void* index) { delete static_cast<faiss::Index*>(index); });

--- a/tenann/index/index_reader.cc
+++ b/tenann/index/index_reader.cc
@@ -19,6 +19,8 @@
 
 #include "tenann/index/index_reader.h"
 #include "tenann/index/parameter_serde.h"
+#include "tenann/util/runtime_profile.h"
+#include "tenann/util/stop_watch.h"
 
 #include "index_reader.h"
 
@@ -33,6 +35,7 @@ IndexReader::~IndexReader() = default;
 const IndexMeta& IndexReader::index_meta() const { return index_meta_; }
 
 IndexRef IndexReader::ReadIndex(const std::string& path) {
+  read_timing_stats_ = {};
   if (!index_reader_options_.cache_index_file) {
     return ReadIndexFile(path);
   }
@@ -50,10 +53,16 @@ IndexRef IndexReader::ReadIndex(const std::string& path) {
   // on the IndexCache implementation (SR's cache single-flights; the default
   // does not). Either way, the loader returns a valid IndexRef and Insert
   // makes it visible — duplicate loads waste I/O but stay correct.
-  (void)index_cache_->GetOrCreate(
-      cache_key,
-      [this, &path]() -> IndexRef { return ReadIndexFile(path); },
-      &cache_handle_);
+  //
+  // cache_lookup_ns covers the whole GetOrCreate window, so on a miss it
+  // also includes the loader's read_file_ns / init_index_ns phases.
+  {
+    ScopedRawTimer<MonotonicStopWatch> timer(&read_timing_stats_.cache_lookup_ns);
+    (void)index_cache_->GetOrCreate(
+        cache_key,
+        [this, &path]() -> IndexRef { return ReadIndexFile(path); },
+        &cache_handle_);
+  }
   return cache_handle_.index_ref();
 }
 

--- a/tenann/index/index_reader.h
+++ b/tenann/index/index_reader.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 #include "tenann/common/json.h"
@@ -28,6 +29,12 @@
 #include "tenann/store/index_file_reader.h"
 
 namespace tenann {
+
+struct IndexReadTimingStats {
+  int64_t cache_lookup_ns = 0;
+  int64_t read_file_ns = 0;
+  int64_t init_index_ns = 0;
+};
 
 class IndexReader {
  public:
@@ -53,6 +60,7 @@ class IndexReader {
   IndexCache* index_cache();
   const IndexCache* index_cache() const;
   IndexFileReaderPtr file_reader() const;
+  const IndexReadTimingStats& read_timing_stats() const { return read_timing_stats_; }
 
  protected:
   /// @brief index meta
@@ -69,6 +77,8 @@ class IndexReader {
   IndexCacheHandle cache_handle_;
   /// @brief optional external file reader for remote file systems
   IndexFileReaderPtr file_reader_;
+  /// @brief timing stats for the last ReadIndex call
+  IndexReadTimingStats read_timing_stats_;
 
   IndexRef ForceReadIndexAndOverwriteCache(const std::string& path, const std::string& cache_key);
 };


### PR DESCRIPTION
## Summary

Add observable per-phase timing for the index read path. **No behavioral change**; all timing fields default to zero and are read-only via the existing IndexReader API.

## Motivation

When the upstream StarRocks BE invokes `IndexReader::ReadIndex` on a vector index file, the wall-clock spent on this call can come from three very different sources:

1. `IndexCache::GetOrCreate` overhead (lookup + handle setup, mostly hits)
2. Actual remote/local file I/O (esp. relevant for shared-data / OSS-backed indexes)
3. Index deserialization / post-read init (notably IVF-PQ's `precompute_table`)

Without phase-level timing, diagnosing slow index loads in production has to fall back to `strace`/`perf`. This PR adds a small `IndexReadTimingStats` struct that splits the three phases into ns-resolution counters readable from `IndexReader::read_timing_stats()`.

## Changes

`IndexReadTimingStats` with three fields:

| Field | Meaning |
|---|---|
| `cache_lookup_ns` | Full `IndexCache::GetOrCreate` window (lookup + handle setup; on cache miss also includes loader invocation, which itself populates the other two fields) |
| `read_file_ns` | Actual file I/O time |
| `init_index_ns` | Deserialization / post-read init time (e.g. IVF-PQ `precompute_table`) |

Hooks:

- **`IndexReader::ReadIndex`** resets stats on entry and wraps `GetOrCreate` with a stopwatch.
- **`FaissIndexReader`** splits remote vs local timing:
  - Remote (via `FaissIOReaderAdapter`): I/O time tracked inside the adapter; deserialization time = total − I/O.
  - Local MMAP: total time accounted as `read_file_ns` since disk I/O is lazy via page faults.
- **`FaissIOReaderAdapter`** accumulates per-`Read()` elapsed time via `MonotonicStopWatch` and exposes `io_time_ns()`.
- **`IndexIvfPqReader`** measures faiss `IndexIVFPQ::precompute_table()` separately and accounts it under `init_index_ns` on both local and remote paths.

## Compatibility

- Public API additions only (one new accessor on `IndexReader`, one new method on `FaissIOReaderAdapter`).
- Existing callers see no change: timing struct defaults to all-zero, and reading the struct is opt-in.
- No change to faiss factory string, index file format, or any other on-disk artifact.

## Testing

- Existing UT continue to pass (no semantic change).
- Validated locally with a small driver that calls `ReadIndex` against (a) a hot cache (sub-µs `cache_lookup_ns`, zero `read_file_ns`/`init_index_ns`), (b) a cold local index (only `read_file_ns`/`init_index_ns` populated), (c) a cold remote index via SR's `IndexFileReader` (`read_file_ns` reflects network I/O, `init_index_ns` reflects faiss deserialization).
