### PR TITLE
[BugFix] Fix unsequenced UB in FaissIvfPqIndexBuilder::InitIndex

### DIFF
--- a/tenann/builder/faiss_ivf_pq_index_builder.cc
+++ b/tenann/builder/faiss_ivf_pq_index_builder.cc
@@ -55,8 +55,13 @@ IndexRef FaissIvfPqIndexBuilder::InitIndex() {
 
     // use bruteforce coarse quantizer by default
     auto quantizer = std::make_unique<faiss::IndexFlat>(common_params_.dim, metric_type);
+    // Pass common_params_.dim (not quantizer->d) as the dim argument. Reading
+    // quantizer->d in the same call expression as quantizer.release() is
+    // unsequenced ([basic.exec]/10) and undefined behavior: if release() is
+    // evaluated first the unique_ptr's stored pointer becomes nullptr, making
+    // quantizer->d a nullptr dereference at offset 8 (faiss::Index::d).
     auto index_ivfpq =
-        std::make_unique<IndexIvfPq>(quantizer.release(), quantizer->d, index_params_.nlist,
+        std::make_unique<IndexIvfPq>(quantizer.release(), common_params_.dim, index_params_.nlist,
                                      index_params_.M, index_params_.nbits, metric_type);
     index_ivfpq->own_fields = true;
 


### PR DESCRIPTION
## Summary

Pass `common_params_.dim` (not `quantizer->d`) as the `d` argument when
constructing `IndexIvfPq` inside `FaissIvfPqIndexBuilder::InitIndex()`.

```cpp
// Before (UB)
auto quantizer = std::make_unique<faiss::IndexFlat>(common_params_.dim, metric_type);
auto index_ivfpq =
    std::make_unique<IndexIvfPq>(quantizer.release(), quantizer->d, ...);

// After
auto index_ivfpq =
    std::make_unique<IndexIvfPq>(quantizer.release(), common_params_.dim, ...);
```

## Why this is undefined behavior

Per `[basic.exec]/10`: if a side effect on a memory location is unsequenced
relative to another side effect, or to a value computation using a value of
any object in the same memory location, the behavior is undefined.

In the previous code, two operations on `quantizer`'s internal pointer storage
appear as arguments to the same call:

- `quantizer.release()` writes `_M_t = nullptr` (side effect)
- `quantizer->d`        reads `_M_t` then dereferences it (value computation
  using the same memory location)

C++17 explicitly leaves the relative evaluation order of function-call
arguments **unsequenced** ([expr.call]/8). With release() and ->d on the same
unique_ptr in the same argument list, this is unconditional UB.

If the compiler happens to evaluate `release()` first (LTR), the unique_ptr's
internal pointer becomes `nullptr` and `quantizer->d` dereferences nullptr at
offset 8 (the `int d` field of `faiss::Index` right after the vtable
pointer) — SIGSEGV with `faddr=0x8`.

GCC/libstdc++ on common x86_64 / aarch64 builds happens to evaluate RTL and
to DSE the release()'s store at -O2, masking the UB in most configurations,
which is why this has been latent since it was introduced. It can fire on:

- different compilers (e.g. clang),
- different STL flavors (libc++),
- LTO/PGO that reorders inlining,
- or any future GCC version that changes scheduling.

## Reproduction context

Observed as a deterministic crash during shared-data lake vertical
compaction of a table with an IVF-PQ vector index:

```
PC: tenann::FaissIvfPqIndexBuilder::InitIndex()
SIGSEGV @ 0x8
  tenann::FaissIndexBuilder::Open(std::string const&)
  starrocks::TenAnnIndexBuilderProxy::init()
  starrocks::VectorIndexWriter::_prepare_index_builder()
  starrocks::VectorIndexWriter::append(...)
  starrocks::ArrayColumnWriter::append(...)
  starrocks::SegmentWriter::append_chunk(...)
  starrocks::lake::VerticalGeneralTabletWriter::write_columns(...)
  starrocks::lake::VerticalCompactionTask::compact_column_group(...)
```

faddr `0x8` matches the layout of `faiss::Index`: vtable pointer (0–7),
`int d` (8–11).

## Fix

`common_params_.dim` is the exact value used to construct the `IndexFlat`
on the line above, so it is by construction equal to what `quantizer->d`
would have returned. Zero semantic change.

This restores the form used in commit `5dea597` (the original IVF-PQ
implementation); the UB was introduced later in commit `41f2d66` when
cosine/inner-product support was added.

## Test plan

- [ ] Existing `TEST_F(FaissIvfPqIndexBuilderTest, Open)` /
      `TEST_F(FaissIvfPqIndexBuilderTest, InitIndex)` continue to pass.
- [ ] Re-run on the aarch64 BE that previously crashed in the compaction
      path described above: SIGSEGV is gone.