### PR TITLE
[BugFix] Charge quantized HNSW index memory by its storage code size

### DIFF
--- a/tenann/index/index.cc
+++ b/tenann/index/index.cc
@@ -20,9 +20,11 @@
 #include "tenann/index/index.h"
 
 #include "faiss/Index.h"
+#include "faiss/IndexFlatCodes.h"
 #include "faiss/IndexHNSW.h"
 #include "faiss/IndexIDMap.h"
 #include "faiss/IndexIVFPQ.h"
+#include "faiss/IndexPQ.h"
 #include "tenann/common/logging.h"
 #include "tenann/index/internal/faiss_index_util.h"
 
@@ -100,8 +102,23 @@ size_t Index::EstimateMemoryUsage() {
                  hnsw.levels.capacity() * sizeof(int) + hnsw.offsets.capacity() * sizeof(size_t) +
                  hnsw.neighbors.size() * sizeof(faiss::HNSW::storage_idx_t);
 
-    // vectors
-    mem_usage += index_hnsw->storage->ntotal * index_hnsw->storage->d * sizeof(float);
+    // vectors: charge the storage index' real code size. It is fp32 only for a flat
+    // storage; the quantized HNSW variants keep compressed codes (SQ8: 1 byte per
+    // dimension, SQ4: 0.5, PQ: m_pq bytes per vector), and charging fp32 for those
+    // inflates the cache charge 4x to 32x.
+    const auto* storage = index_hnsw->storage;
+    size_t code_size = static_cast<size_t>(storage->d) * sizeof(float);
+    if (const auto* flat_codes = dynamic_cast<const faiss::IndexFlatCodes*>(storage)) {
+      code_size = flat_codes->code_size;
+    }
+    mem_usage += static_cast<size_t>(storage->ntotal) * code_size;
+
+    // The PQ codebook is shared by all vectors, so it is not covered by the per-vector
+    // code size above. It is fixed-size (2^nbits * dim floats), which makes it the
+    // dominant term for a small segment at high dim.
+    if (const auto* pq_storage = dynamic_cast<const faiss::IndexPQ*>(storage)) {
+      mem_usage += pq_storage->pq.centroids.capacity() * sizeof(float);
+    }
 
     return mem_usage;
   }

--- a/test/index/test_index.cc
+++ b/test/index/test_index.cc
@@ -15,8 +15,41 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+#include <memory>
+#include <random>
+#include <vector>
+
+#include "faiss/IndexHNSW.h"
+#include "faiss/index_factory.h"
 
 namespace tenann {
+
+namespace {
+
+constexpr uint32_t kDim = 64;
+// >= 39 * 256 so PQ8 training never falls below faiss' min-points-per-centroid
+// (a smaller set only prints a clustering warning, but keeps test output noisy).
+constexpr uint32_t kNumRows = 10000;
+
+std::vector<float> RandomVectors(uint32_t n, uint32_t dim) {
+  std::mt19937 rng(42);
+  std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+  std::vector<float> v(static_cast<size_t>(n) * dim);
+  for (auto& x : v) x = dist(rng);
+  return v;
+}
+
+// Builds a real HNSW index with the given storage quantizer and returns the
+// tenann::Index wrapper the cache charges through.
+std::unique_ptr<Index> BuildHnsw(const char* factory_string, const std::vector<float>& data) {
+  auto* raw = faiss::index_factory(kDim, factory_string, faiss::METRIC_L2);
+  raw->train(kNumRows, data.data());
+  raw->add(kNumRows, data.data());
+  return std::make_unique<Index>(raw, IndexType::kFaissHnsw,
+                                 [](void* p) { delete static_cast<faiss::Index*>(p); });
+}
+
+}  // namespace
 
 TEST(IndexExplicitBytes, ReturnsExplicitBytesWhenSet) {
   void* buf = std::malloc(128);
@@ -32,6 +65,44 @@ TEST(IndexExplicitBytes, UnsupportedTypeReturnsOne) {
   // real faiss::Index or triggering a static_cast on garbage memory.
   Index idx(nullptr, IndexType::kFaissIvfPqOneInvertedList, [](void*) {});
   EXPECT_EQ(1u, idx.EstimateMemoryUsage());
+}
+
+// A quantized HNSW stores compressed codes, not fp32 vectors, so its charge must
+// drop by exactly the bytes the quantizer saves. Charging fp32 unconditionally
+// inflates the cache charge 4x (SQ8) to 32x (PQ), which shrinks the effective
+// cache capacity and makes the vector_index memory metrics unusable.
+TEST(IndexMemoryUsage, ChargesQuantizedHnswByStorageCodeSize) {
+  const auto data = RandomVectors(kNumRows, kDim);
+  const size_t vectors_fp32 = static_cast<size_t>(kNumRows) * kDim * sizeof(float);
+
+  auto flat = BuildHnsw("HNSW8,Flat", data);
+  auto sq8 = BuildHnsw("HNSW8,SQ8", data);
+  auto pq8 = BuildHnsw("HNSW8,PQ8", data);
+
+  const size_t flat_usage = flat->EstimateMemoryUsage();
+  const size_t sq8_usage = sq8->EstimateMemoryUsage();
+  const size_t pq8_usage = pq8->EstimateMemoryUsage();
+
+  // SQ8 keeps 1 byte per dimension instead of 4, so it saves 3/4 of the vector bytes.
+  // The graph is identical across the three (same data, same M => same level
+  // assignment), so the whole delta is the storage term.
+  EXPECT_LT(sq8_usage, flat_usage);
+  EXPECT_EQ(flat_usage - sq8_usage, vectors_fp32 / 4 * 3);
+
+  // PQ8 keeps 8 bytes per vector regardless of dim, plus one shared codebook of
+  // m * 2^nbits * (dim/m) = 2^nbits * dim floats. For a small segment at high dim the
+  // codebook can outweigh the codes, so it must be charged too.
+  const size_t pq_codebook = 256 * static_cast<size_t>(kDim) * sizeof(float);
+  EXPECT_LT(pq8_usage, sq8_usage);
+  EXPECT_EQ(flat_usage - pq8_usage, vectors_fp32 - static_cast<size_t>(kNumRows) * 8 - pq_codebook);
+}
+
+// Guards the other direction: the fix must not undercharge a non-quantized index,
+// whose storage really is fp32.
+TEST(IndexMemoryUsage, StillChargesFlatHnswAsFp32) {
+  const auto data = RandomVectors(kNumRows, kDim);
+  auto flat = BuildHnsw("HNSW8,Flat", data);
+  EXPECT_GE(flat->EstimateMemoryUsage(), static_cast<size_t>(kNumRows) * kDim * sizeof(float));
 }
 
 }  // namespace tenann


### PR DESCRIPTION
## Why I'm doing

`Index::EstimateMemoryUsage()` is the single source of the cache charge: both the tenann
`DefaultIndexCache` and the StarRocks-owned `VectorIndexCache` size their entries with it.
Its HNSW branch charges the vector storage as fp32 unconditionally:

```cpp
mem_usage += index_hnsw->storage->ntotal * index_hnsw->storage->d * sizeof(float);
```

But for the quantized HNSW variants the storage index keeps compressed codes, not fp32
vectors — SQ8 is 1 byte per dimension, SQ4 is 0.5, PQ is `m_pq` bytes per vector. Nothing
compensates for it: `explicit_bytes_` (which would bypass the estimate) is only set by the
IVF-PQ reader, and the HNSW factory string has no `RFlat` refine wrapper, so there is no
second fp32 copy being accounted for.

The result is that flat, SQ8 and PQ indexes over the same data are charged the exact same
number of bytes. Measured in the new test (dim=64, 10k rows), all three came out at
**3,442,176 bytes** before this change.

Consequences:

- the cache holds ~4x (SQ8) to ~18x (PQ, dim=1536/m_pq=192) fewer quantized indexes than
  its configured capacity allows, so quantized indexes get evicted far earlier than flat ones;
- `vector_index_cache_usage` and the `vector_index` memory tracker over-report, which makes
  them unusable as evidence when measuring how much memory quantization actually saves.

Correctness and real RSS are unaffected — this is purely an accounting defect.

## What I'm doing

Charge the storage index' real code size instead of assuming fp32. `IndexFlat`,
`IndexScalarQuantizer` and `IndexPQ` all derive from `faiss::IndexFlatCodes`, so a single
`dynamic_cast` covers every HNSW storage kind, and flat keeps its previous value
(`IndexFlatCodes::code_size` is `d * sizeof(float)` there). The fp32 computation stays as
the fallback for any storage that is not an `IndexFlatCodes`.

Also charge the PQ codebook (`pq.centroids`). It is shared by all vectors, so the per-vector
code size does not cover it, and being fixed-size (`2^nbits * dim` floats) it dominates for a
small segment at high dim — at dim=1536 / m_pq=192, a 10k-row segment has 1.9 MB of codes
and a 1.5 MB codebook.

The IVF-PQ branch is left alone: it is already quantizer-aware
(`invlists->compute_ntotal() * (code_size + sizeof(idx_t))`), and its reader bypasses the
estimate through `explicit_bytes_` anyway.

Charges after the change, for the same three indexes (graph + IDMap account for the shared
882,176 bytes):

| storage | before | after |
|---|---|---|
| `HNSW8,Flat` | 3,442,176 | 3,442,176 (unchanged) |
| `HNSW8,SQ8` | 3,442,176 | 1,522,176 |
| `HNSW8,PQ8` | 3,442,176 | 1,027,712 |

## Tests

Added to `test/index/test_index.cc`, next to the existing `EstimateMemoryUsage` tests:

- `IndexMemoryUsage.ChargesQuantizedHnswByStorageCodeSize` — builds three real HNSW indexes
  (`HNSW8,Flat` / `,SQ8` / `,PQ8`) over the same 10k vectors and asserts the exact charge
  deltas: SQ8 saves 3/4 of the vector bytes, PQ8 keeps 8 bytes per vector plus one codebook.
  The graph is identical across the three (same data, same M, so the same level assignment),
  which is what makes an exact equality assertion possible instead of a range.
- `IndexMemoryUsage.StillChargesFlatHnswAsFp32` — guards the other direction, so a
  non-quantized index is not undercharged.

Both were confirmed to fail before the fix (the first reported a 0-byte delta between flat
and SQ8, the second passed as a regression guard). Full suite: 116/116 passing.
