### PR TITLE
[BugFix] Fix IVF-PQ block cache safety and accounting

### DIFF
--- a/tenann/index/index.cc
+++ b/tenann/index/index.cc
@@ -26,6 +26,7 @@
 #include "faiss/IndexIVFPQ.h"
 #include "faiss/IndexPQ.h"
 #include "tenann/common/logging.h"
+#include "tenann/index/index_ivfpq_reader.h"
 #include "tenann/index/internal/faiss_index_util.h"
 
 namespace tenann {
@@ -146,7 +147,7 @@ size_t Index::EstimateMemoryUsage() {
     // IndexIvfPq
     mem_usage += sizeof(*index_ivf_pq);
     // IndexIvfPq.reconstruction_errors
-    for (auto reconstruction_error : index_ivf_pq->reconstruction_errors) {
+    for (const auto& reconstruction_error : index_ivf_pq->reconstruction_errors) {
       mem_usage += sizeof(reconstruction_error);
       mem_usage += reconstruction_error.capacity() * sizeof(float);
     }
@@ -158,9 +159,14 @@ size_t Index::EstimateMemoryUsage() {
 
     // IndexIVF.InvertedLists
     if (index_ivf_pq->invlists != nullptr) {
-      mem_usage += sizeof(*index_ivf_pq->invlists);
-      mem_usage += index_ivf_pq->invlists->compute_ntotal() *
-                   (index_ivf_pq->code_size + sizeof(faiss::idx_t));
+      if (const auto* block_cache_invlists =
+              dynamic_cast<const faiss::BlockCacheInvertedLists*>(index_ivf_pq->invlists)) {
+        mem_usage += block_cache_invlists->EstimateMemoryUsage();
+      } else {
+        mem_usage += sizeof(*index_ivf_pq->invlists);
+        mem_usage += index_ivf_pq->invlists->compute_ntotal() *
+                     (index_ivf_pq->code_size + sizeof(faiss::idx_t));
+      }
     }
 
     // IndexIVF.DirectMap

--- a/tenann/index/index_ivfpq_reader.cc
+++ b/tenann/index/index_ivfpq_reader.cc
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 
 #include "faiss/Index.h"
 #include "faiss/IndexIVFPQR.h"
@@ -255,21 +256,35 @@ BlockCacheInvertedLists::~BlockCacheInvertedLists() {
 
 size_t BlockCacheInvertedLists::list_size(size_t list_no) const { return lists[list_no].size; }
 
+size_t BlockCacheInvertedLists::EstimateMemoryUsage() const {
+  size_t mem_usage = sizeof(*this);
+  mem_usage += lists.capacity() * sizeof(List);
+  mem_usage += cache_keys.capacity() * sizeof(std::string);
+  for (const auto& cache_key : cache_keys) {
+    mem_usage += cache_key.capacity();
+  }
+  mem_usage += offset_difference.capacity() * sizeof(size_t);
+  mem_usage += cache_handles.capacity() * sizeof(tenann::IndexCacheHandle);
+  mem_usage += invlist_locks.capacity() * sizeof(std::mutex);
+  mem_usage += filename.capacity();
+  return mem_usage;
+}
+
 const uint8_t* BlockCacheInvertedLists::get_ptr(size_t list_no) const {
   T_CHECK(index_cache != nullptr)
       << "IndexCache not injected. "
       << "Call tenann::SetGlobalIndexCache() during process initialization "
       << "before constructing readers/searchers.";
   T_CHECK(list_no < nlist);
-  {
-    std::lock_guard<std::mutex> guard(invlist_locks[list_no]);
-    tenann::IndexCacheHandle* cache_handle = &cache_handles[list_no];
-    auto found = index_cache->Lookup(cache_keys[list_no], cache_handle);
-    if (found) {
-      VLOG(VERBOSE_DEBUG) << "   hit cache, cache_key: " << cache_keys[list_no].c_str();
-      auto start_ptr = static_cast<uint8_t*>(cache_handle->index_ref()->index_raw());
-      return start_ptr + offset_difference[list_no];
-    }
+  // Keep lookup, load, and insert in one per-list critical section. IndexCache
+  // implementations are not required to single-flight concurrent misses.
+  std::lock_guard<std::mutex> guard(invlist_locks[list_no]);
+  tenann::IndexCacheHandle* cache_handle = &cache_handles[list_no];
+  auto found = index_cache->Lookup(cache_keys[list_no], cache_handle);
+  if (found) {
+    VLOG(VERBOSE_DEBUG) << "   hit cache, cache_key: " << cache_keys[list_no].c_str();
+    auto start_ptr = static_cast<uint8_t*>(cache_handle->index_ref()->index_raw());
+    return start_ptr + offset_difference[list_no];
   }
 
   // read file and insert
@@ -279,15 +294,17 @@ const uint8_t* BlockCacheInvertedLists::get_ptr(size_t list_no) const {
   size_t size = lists[list_no].size * one_entry_size;
 
   ssize_t read_bytes = 0;
-  void* buffer = nullptr;
+  size_t allocated_bytes = 0;
+  std::unique_ptr<void, decltype(&free)> buffer(nullptr, &free);
 
   if (file_reader) {
     // ---- Remote file system path: use IndexFileReader::ReadAt ----
     // No O_DIRECT / alignment needed for remote FS.
-    buffer = malloc(size);
+    buffer.reset(malloc(size));
     FAISS_THROW_IF_NOT_FMT(buffer != nullptr, "malloc(%zu) failed", size);
+    allocated_bytes = size;
 
-    read_bytes = file_reader->ReadAt(offset, buffer, size);
+    read_bytes = file_reader->ReadAt(offset, buffer.get(), size);
     FAISS_THROW_IF_NOT_FMT(read_bytes == static_cast<ssize_t>(size),
                            "ReadAt: read_bytes: %zd, expected: %zu", read_bytes, size);
 
@@ -302,39 +319,35 @@ const uint8_t* BlockCacheInvertedLists::get_ptr(size_t list_no) const {
     // Adjust the size to read to include the data from the aligned offset
     size_t aligned_size =
         ((offset_difference[list_no] + size + block_size - 1) / block_size) * block_size;
+    allocated_bytes = aligned_size;
 
     // Allocate aligned memory
-    int err = posix_memalign(&buffer, block_size, aligned_size);
+    void* aligned_buffer = nullptr;
+    int err = posix_memalign(&aligned_buffer, block_size, aligned_size);
     FAISS_THROW_IF_NOT_FMT(err == 0, "posix_memalign error: %d", err);
-
-    // Seek to the aligned offset
-    off_t seek_result = lseek(fd, aligned_offset, SEEK_SET);
-    FAISS_THROW_IF_NOT_FMT(seek_result != -1, "lseek to aligned_offset %zu failed: %s",
-                           aligned_offset, strerror(errno));
+    buffer.reset(aligned_buffer);
 
     size_t remaining_size = totsize - aligned_offset;
     size_t expected_read_size = std::min(remaining_size, aligned_size);
-    // Perform the read operation
-    read_bytes = read(fd, buffer, aligned_size);
+    do {
+      read_bytes = pread(fd, buffer.get(), aligned_size, aligned_offset);
+    } while (read_bytes == -1 && errno == EINTR);
     FAISS_THROW_IF_NOT_FMT(read_bytes == expected_read_size,
-                           "read_bytes: %zd, expected_read_size: %zu", read_bytes,
-                           expected_read_size);
+                           "pread: read_bytes: %zd, expected_read_size: %zu, error: %s", read_bytes,
+                           expected_read_size, strerror(errno));
   }
 
   auto index_ref = std::make_shared<tenann::Index>(
-      buffer, tenann::IndexType::kFaissIvfPqOneInvertedList,
-      [](void* index) { free(index); },
-      /*explicit_bytes=*/static_cast<size_t>(read_bytes));
+      buffer.get(), tenann::IndexType::kFaissIvfPqOneInvertedList, [](void* index) { free(index); },
+      /*explicit_bytes=*/allocated_bytes);
+  buffer.release();
 
-  {
-    std::lock_guard<std::mutex> guard(invlist_locks[list_no]);
-    tenann::IndexCacheHandle* cache_handle = &cache_handles[list_no];
-    index_cache->Insert(cache_keys[list_no], index_ref, cache_handle);
+  index_cache->Insert(cache_keys[list_no], index_ref, cache_handle);
 
-    VLOG(VERBOSE_DEBUG) << "insert cache, cache_key: " << cache_keys[list_no].c_str();
-  }
+  VLOG(VERBOSE_DEBUG) << "insert cache, cache_key: " << cache_keys[list_no].c_str();
 
-  return static_cast<uint8_t*>(buffer) + offset_difference[list_no];
+  auto start_ptr = static_cast<uint8_t*>(cache_handle->index_ref()->index_raw());
+  return start_ptr + offset_difference[list_no];
 }
 
 const uint8_t* BlockCacheInvertedLists::get_codes(size_t list_no) const {

--- a/tenann/index/index_ivfpq_reader.h
+++ b/tenann/index/index_ivfpq_reader.h
@@ -65,6 +65,9 @@ struct BlockCacheInvertedLists : InvertedLists {
                           tenann::IndexCache* index_cache);
 
   size_t list_size(size_t list_no) const override;
+  /// Estimate resident metadata only. Per-list buffers are owned and charged
+  /// by their individual cache entries.
+  size_t EstimateMemoryUsage() const;
   const uint8_t* get_ptr(size_t list_no) const;
   const uint8_t* get_codes(size_t list_no) const override;
   const idx_t* get_ids(size_t list_no) const override;

--- a/tenann/store/index_file_reader.h
+++ b/tenann/store/index_file_reader.h
@@ -39,7 +39,8 @@ class IndexFileReader {
   virtual int64_t Read(void* data, int64_t count) = 0;
 
   /// Random read: read up to |count| bytes starting at |offset|.
-  /// The current position is not affected.
+  /// The current position is not affected. Concurrent calls to ReadAt must be
+  /// safe and must not interfere with each other's offsets.
   /// Returns the number of bytes actually read, or -1 on error.
   virtual int64_t ReadAt(int64_t offset, void* data, int64_t count) = 0;
 

--- a/test/index/test_index_ivfpq.cc
+++ b/test/index/test_index_ivfpq.cc
@@ -17,14 +17,96 @@
  * under the License.
  */
 
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
 #include "faiss/IndexFlat.h"
 #include "faiss/utils/distances.h"
 #include "gtest/gtest.h"
+#include "tenann/index/default_index_cache.h"
+#include "tenann/index/index.h"
+#include "tenann/index/index_ivfpq_reader.h"
 #include "tenann/index/index_ivfpq_util.h"
 #include "tenann/index/internal/index_ivfpq.h"
+#include "tenann/store/index_file_reader.h"
 #include "tenann/util/random.h"
 
 const float float_diff_threshold = 0.000001;
+
+namespace {
+
+class ConcurrentIndexFileReader : public tenann::IndexFileReader {
+ public:
+  explicit ConcurrentIndexFileReader(std::string payload, std::chrono::milliseconds delay = {})
+      : payload_(std::move(payload)), delay_(delay) {}
+
+  int64_t Read(void* data, int64_t count) override { return -1; }
+
+  int64_t ReadAt(int64_t offset, void* data, int64_t count) override {
+    read_count_.fetch_add(1, std::memory_order_relaxed);
+    int active = active_reads_.fetch_add(1, std::memory_order_acq_rel) + 1;
+    int observed = max_active_reads_.load(std::memory_order_relaxed);
+    while (active > observed &&
+           !max_active_reads_.compare_exchange_weak(observed, active, std::memory_order_relaxed)) {
+    }
+    std::this_thread::sleep_for(delay_);
+
+    if (offset < 0 || count < 0 || offset + count > static_cast<int64_t>(payload_.size())) {
+      active_reads_.fetch_sub(1, std::memory_order_release);
+      return -1;
+    }
+    memcpy(data, payload_.data() + offset, count);
+    active_reads_.fetch_sub(1, std::memory_order_release);
+    return count;
+  }
+
+  void Seek(int64_t position) override {}
+  int64_t GetSize() override { return payload_.size(); }
+  const std::string& filename() const override { return filename_; }
+
+  int read_count() const { return read_count_.load(std::memory_order_relaxed); }
+  int max_active_reads() const { return max_active_reads_.load(std::memory_order_relaxed); }
+
+ private:
+  std::string payload_;
+  std::chrono::milliseconds delay_;
+  std::string filename_ = "remote-index";
+  std::atomic<int> read_count_{0};
+  std::atomic<int> active_reads_{0};
+  std::atomic<int> max_active_reads_{0};
+};
+
+class FailingIndexFileReader : public tenann::IndexFileReader {
+ public:
+  int64_t Read(void* data, int64_t count) override { return -1; }
+  int64_t ReadAt(int64_t offset, void* data, int64_t count) override { return -1; }
+  void Seek(int64_t position) override {}
+  int64_t GetSize() override { return 4096; }
+  const std::string& filename() const override { return filename_; }
+
+ private:
+  std::string filename_ = "failing-index";
+};
+
+void WaitAndStartThreads(std::vector<std::thread>* threads, std::atomic<int>* ready,
+                         std::atomic<bool>* start, int expected_threads) {
+  while (ready->load(std::memory_order_acquire) != expected_threads) {
+    std::this_thread::yield();
+  }
+  start->store(true, std::memory_order_release);
+  for (auto& thread : *threads) {
+    thread.join();
+  }
+}
+
+}  // namespace
 
 TEST(IndexIvfPqTest, test_reconstruction_error) {
   const int dim = 8;
@@ -66,4 +148,128 @@ TEST(IndexIvfPqTest, test_index_ivfpq_util) {
   meta.index_params()["nlist"] = 300;
   auto min2 = tenann::GetIvfPqMinRows(meta, 1);
   EXPECT_EQ(min2, 300);
+}
+
+TEST(IndexIvfPqTest, block_cache_single_flights_same_list_miss) {
+  constexpr int kThreads = 8;
+  tenann::DefaultIndexCache cache(1024 * 1024);
+  auto reader = std::make_shared<ConcurrentIndexFileReader>(std::string(64, 'a'),
+                                                            std::chrono::milliseconds(10));
+  faiss::BlockCacheInvertedLists lists(1, 1, "remote-index", &cache);
+  lists.file_reader = reader;
+  lists.one_entry_size = 1;
+  lists.lists[0].offset = 0;
+  lists.lists[0].size = 64;
+  lists.cache_keys[0] = "same-list";
+
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+  std::vector<uint8_t> results(kThreads);
+  std::vector<std::thread> threads;
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&, i] {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      results[i] = lists.get_ptr(0)[0];
+    });
+  }
+  WaitAndStartThreads(&threads, &ready, &start, kThreads);
+
+  EXPECT_EQ(reader->read_count(), 1);
+  for (uint8_t result : results) {
+    EXPECT_EQ(result, 'a');
+  }
+}
+
+TEST(IndexIvfPqTest, block_cache_keeps_different_remote_list_reads_concurrent) {
+  constexpr int kThreads = 4;
+  constexpr size_t kListSize = 64;
+  tenann::DefaultIndexCache cache(1024 * 1024);
+  auto reader = std::make_shared<ConcurrentIndexFileReader>(std::string(kThreads * kListSize, 'b'),
+                                                            std::chrono::milliseconds(50));
+  faiss::BlockCacheInvertedLists lists(kThreads, 1, "remote-index", &cache);
+  lists.file_reader = reader;
+  lists.one_entry_size = 1;
+  for (int i = 0; i < kThreads; ++i) {
+    lists.lists[i].offset = i * kListSize;
+    lists.lists[i].size = kListSize;
+    lists.cache_keys[i] = "different-list-" + std::to_string(i);
+  }
+
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+  std::vector<std::thread> threads;
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&, i] {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      EXPECT_EQ(lists.get_ptr(i)[0], 'b');
+    });
+  }
+  WaitAndStartThreads(&threads, &ready, &start, kThreads);
+
+  EXPECT_GT(reader->max_active_reads(), 1);
+}
+
+TEST(IndexIvfPqTest, block_cache_releases_remote_buffer_after_read_failure) {
+  tenann::DefaultIndexCache cache(1024 * 1024);
+  auto reader = std::make_shared<FailingIndexFileReader>();
+  faiss::BlockCacheInvertedLists lists(1, 1, "failing-index", &cache);
+  lists.file_reader = reader;
+  lists.one_entry_size = 1;
+  lists.lists[0].offset = 0;
+  lists.lists[0].size = 4096;
+  lists.cache_keys[0] = "read-failure";
+
+  // The ownership assertion is provided by LeakSanitizer in the ASAN build.
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_ANY_THROW(lists.get_ptr(0));
+  }
+}
+
+TEST(IndexIvfPqTest, block_cache_charges_allocated_local_buffer_size) {
+  char path[] = "/tmp/tenann-block-cache-XXXXXX";
+  int fd = mkstemp(path);
+  ASSERT_NE(fd, -1);
+  unlink(path);
+
+  const std::string payload = "0123456789";
+  ASSERT_EQ(write(fd, payload.data(), payload.size()), static_cast<ssize_t>(payload.size()));
+
+  tenann::DefaultIndexCache cache(1024 * 1024);
+  faiss::BlockCacheInvertedLists lists(1, 1, path, &cache);
+  lists.fd = fd;
+  lists.block_size = sizeof(void*);
+  lists.totsize = payload.size();
+  lists.one_entry_size = 1;
+  lists.lists[0].offset = 0;
+  lists.lists[0].size = payload.size();
+  lists.cache_keys[0] = "local-aligned-buffer";
+
+  const uint8_t* data = lists.get_ptr(0);
+  EXPECT_EQ(memcmp(data, payload.data(), payload.size()), 0);
+  EXPECT_EQ(cache.memory_usage(), 2 * sizeof(void*));
+}
+
+TEST(IndexIvfPqTest, block_cache_top_level_charge_excludes_list_payloads) {
+  faiss::IndexFlatL2 quantizer(8);
+  auto* ivfpq = new tenann::IndexIvfPq(&quantizer, 8, 2, 2, 8);
+  auto* lists = new faiss::BlockCacheInvertedLists(2, ivfpq->code_size, "remote-index", nullptr);
+  lists->lists[0].size = 1000000;
+  lists->lists[1].size = 2000000;
+  lists->cache_keys[0] = "metadata-list-0";
+  lists->cache_keys[1] = "metadata-list-1";
+  ivfpq->replace_invlists(lists, true);
+
+  tenann::Index index(ivfpq, tenann::IndexType::kFaissIvfPq,
+                      [](void* raw) { delete static_cast<faiss::Index*>(raw); });
+  size_t large_lists_estimate = index.EstimateMemoryUsage();
+  lists->lists[0].size = 1;
+  lists->lists[1].size = 2;
+
+  EXPECT_EQ(index.EstimateMemoryUsage(), large_lists_estimate);
 }

--- a/test/index/test_index_ivfpq.cc
+++ b/test/index/test_index_ivfpq.cc
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -186,9 +187,13 @@ TEST(IndexIvfPqTest, block_cache_single_flights_same_list_miss) {
 TEST(IndexIvfPqTest, block_cache_keeps_different_remote_list_reads_concurrent) {
   constexpr int kThreads = 4;
   constexpr size_t kListSize = 64;
+  std::string payload(kThreads * kListSize, '\0');
+  for (int i = 0; i < kThreads; ++i) {
+    std::fill_n(payload.begin() + i * kListSize, kListSize, static_cast<char>('a' + i));
+  }
+
   tenann::DefaultIndexCache cache(1024 * 1024);
-  auto reader = std::make_shared<ConcurrentIndexFileReader>(std::string(kThreads * kListSize, 'b'),
-                                                            std::chrono::milliseconds(50));
+  auto reader = std::make_shared<ConcurrentIndexFileReader>(payload, std::chrono::milliseconds(50));
   faiss::BlockCacheInvertedLists lists(kThreads, 1, "remote-index", &cache);
   lists.file_reader = reader;
   lists.one_entry_size = 1;
@@ -200,6 +205,7 @@ TEST(IndexIvfPqTest, block_cache_keeps_different_remote_list_reads_concurrent) {
 
   std::atomic<int> ready{0};
   std::atomic<bool> start{false};
+  std::vector<int> content_matches(kThreads);
   std::vector<std::thread> threads;
   for (int i = 0; i < kThreads; ++i) {
     threads.emplace_back([&, i] {
@@ -207,12 +213,64 @@ TEST(IndexIvfPqTest, block_cache_keeps_different_remote_list_reads_concurrent) {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      EXPECT_EQ(lists.get_ptr(i)[0], 'b');
+      const uint8_t* data = lists.get_ptr(i);
+      content_matches[i] = memcmp(data, payload.data() + i * kListSize, kListSize) == 0;
     });
   }
   WaitAndStartThreads(&threads, &ready, &start, kThreads);
 
+  EXPECT_EQ(reader->read_count(), kThreads);
   EXPECT_GT(reader->max_active_reads(), 1);
+  for (int content_match : content_matches) {
+    EXPECT_TRUE(content_match);
+  }
+}
+
+TEST(IndexIvfPqTest, block_cache_reads_different_local_lists_by_position) {
+  constexpr int kThreads = 8;
+  constexpr size_t kListSize = 4096;
+  char path[] = "/tmp/tenann-block-cache-concurrent-XXXXXX";
+  int fd = mkstemp(path);
+  ASSERT_NE(fd, -1);
+  unlink(path);
+
+  std::string payload(kThreads * kListSize, '\0');
+  for (int i = 0; i < kThreads; ++i) {
+    std::fill_n(payload.begin() + i * kListSize, kListSize, static_cast<char>('a' + i));
+  }
+  ASSERT_EQ(pwrite(fd, payload.data(), payload.size(), 0), static_cast<ssize_t>(payload.size()));
+
+  tenann::DefaultIndexCache cache(2 * payload.size());
+  faiss::BlockCacheInvertedLists lists(kThreads, 1, path, &cache);
+  lists.fd = fd;
+  lists.block_size = kListSize;
+  lists.totsize = payload.size();
+  lists.one_entry_size = 1;
+  for (int i = 0; i < kThreads; ++i) {
+    lists.lists[i].offset = i * kListSize;
+    lists.lists[i].size = kListSize;
+    lists.cache_keys[i] = "local-list-" + std::to_string(i);
+  }
+
+  std::atomic<int> ready{0};
+  std::atomic<bool> start{false};
+  std::vector<int> content_matches(kThreads);
+  std::vector<std::thread> threads;
+  for (int i = 0; i < kThreads; ++i) {
+    threads.emplace_back([&, i] {
+      ready.fetch_add(1, std::memory_order_release);
+      while (!start.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+      }
+      const uint8_t* data = lists.get_ptr(i);
+      content_matches[i] = memcmp(data, payload.data() + i * kListSize, kListSize) == 0;
+    });
+  }
+  WaitAndStartThreads(&threads, &ready, &start, kThreads);
+
+  for (int content_match : content_matches) {
+    EXPECT_TRUE(content_match);
+  }
 }
 
 TEST(IndexIvfPqTest, block_cache_releases_remote_buffer_after_read_failure) {


### PR DESCRIPTION
## Why

The IVF-PQ block cache had several independent safety and accounting problems:

- Concurrent cold misses for the same inverted list could both load and insert a buffer. Because `IndexCache` does not require single-flight behavior, the second insert could replace the first entry while the first caller still used its raw pointer.
- The local path shared one file descriptor across lists and used `lseek` followed by `read`, allowing concurrent list loads to interfere with the file offset.
- Buffers allocated before local or remote reads leaked when a read or validation failed.
- A block-backed IVF-PQ index charged all list payload bytes at the top-level entry even though list buffers were separately cached. This charged nonresident lists and double-counted resident lists.

## What

- Hold the existing per-list lock across lookup, load, and insert, and return the pointer owned by the installed cache handle.
- Replace local `lseek` plus `read` with positional `pread`, including EINTR retry.
- Own newly allocated buffers with RAII until ownership transfers to the cache entry, and charge the actual allocated bytes.
- Add metadata-only accounting for `BlockCacheInvertedLists`; list payloads remain charged by their individual cache entries.
- Document that `IndexFileReader::ReadAt` is a concurrent positioned-read contract.
- Add concurrency, failure-path, aligned-allocation accounting, and top-level accounting tests.

## Performance

- Cache-hit synchronization is unchanged: the same per-list mutex and lookup are used.
- Same-list cold misses now perform one I/O instead of duplicate I/O. In the test with eight concurrent callers and a simulated 10 ms read, all callers complete in about 10-11 ms and the reader is invoked once.
- Different-list remote reads are not globally serialized. Four concurrent simulated 50 ms reads complete in about 50-51 ms rather than about 200 ms.
- Local reads use one positional syscall instead of `lseek` plus `read`.
- Metadata accounting runs only when the top-level index is charged, not in the query hot path.

## Tests

- `CCACHE_DISABLE=1 TENANN_GCC_HOME=/usr bash build.sh --with-tests --with-avx2`
- `build_Release/test/tenann_test` (122 passed)
- `build_Release/test/tenann_test_avx2` (122 passed)
- `TENANN_THIRDPARTY=$PWD/thirdparty cmake -S . -B build_Asan -G Ninja -DCMAKE_BUILD_TYPE=Debug '-DCMAKE_CXX_FLAGS=-fsanitize=address -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address -DWITH_TESTS=ON -DWITH_EXAMPLES=OFF -DWITH_AVX2=OFF -DWITH_PYTHON=OFF`
- `ninja -C build_Asan test/tenann_test`
- `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 build_Asan/test/tenann_test --gtest_filter=IndexIvfPqTest.block_cache_*` (6 passed)
- The remote and local different-list concurrency tests passed 100 repeated runs.

## Scope

This PR intentionally does not change the long-lived per-list cache handles. Releasing those handles and redesigning list pin lifetimes is the separate P1-02 follow-up.

Because different remote lists remain concurrent for performance, integrations must provide a concurrency-safe `ReadAt`. The current StarRocks `VectorIndexFileReader` bridge needs a companion fix before relying on concurrent remote cold loads.
